### PR TITLE
修复每帧重开 ALSA mixer 导致的 D-Bus 连接风暴(PipeWire 下每秒 ~30 条)

### DIFF
--- a/src/tmplayer/utils/system_volume.rs
+++ b/src/tmplayer/utils/system_volume.rs
@@ -4,6 +4,11 @@ mod imp {
     use anyhow::{Result, anyhow};
 
     pub struct SystemVolume {
+        // Keep the mixer open for the process lifetime. Reopening it per call
+        // spawns a fresh PipeWire client context each time on PipeWire systems,
+        // which performs a D-Bus RTKit handshake per open; polled every frame
+        // that floods the session bus with ~30 connections/s.
+        mixer: Mixer,
         selem_id: SelemId,
         elem_name: String,
     }
@@ -17,17 +22,20 @@ mod imp {
             // 1) Prefer common element names.
             for name in preferred {
                 let id = SelemId::new(name, 0);
-                if let Some(selem) = mixer.find_selem(&id) {
-                    if selem.has_playback_volume() {
-                        return Ok(Self {
-                            selem_id: id,
-                            elem_name: name.to_string(),
-                        });
-                    }
+                let found = mixer
+                    .find_selem(&id)
+                    .is_some_and(|selem| selem.has_playback_volume());
+                if found {
+                    return Ok(Self {
+                        mixer,
+                        selem_id: id,
+                        elem_name: name.to_string(),
+                    });
                 }
             }
 
             // 2) Fall back to the first element that has playback volume.
+            let mut fallback = None;
             for elem in mixer.iter() {
                 let Some(selem) = Selem::new(elem) else {
                     continue;
@@ -37,7 +45,12 @@ mod imp {
                 }
                 let sid = selem.get_id();
                 let name = sid.get_name().unwrap_or("Unknown").to_string();
+                fallback = Some((sid, name));
+                break;
+            }
+            if let Some((sid, name)) = fallback {
                 return Ok(Self {
+                    mixer,
                     selem_id: sid,
                     elem_name: name,
                 });
@@ -47,8 +60,10 @@ mod imp {
         }
 
         pub fn get(&self) -> Result<f32> {
-            let mixer = Mixer::new("default", false)?;
-            let selem = mixer
+            // Pump pending mixer events so cached element values are current.
+            self.mixer.handle_events()?;
+            let selem = self
+                .mixer
                 .find_selem(&self.selem_id)
                 .ok_or_else(|| anyhow!("ALSA element not found: {}", self.elem_name))?;
 
@@ -85,8 +100,9 @@ mod imp {
         }
 
         pub fn set(&self, volume: f32) -> Result<()> {
-            let mixer = Mixer::new("default", false)?;
-            let selem = mixer
+            self.mixer.handle_events()?;
+            let selem = self
+                .mixer
                 .find_selem(&self.selem_id)
                 .ok_or_else(|| anyhow!("ALSA element not found: {}", self.elem_name))?;
 


### PR DESCRIPTION
你好!先说声谢谢,cnmplayer 是我日常主力播放器,用得很开心 😄

不过今天我的桌面出了个大事故,排查了半天最后追到了 cnmplayer 这边,顺手把它修了。

## 发生了什么

某天我的文件管理器突然打不开了,一路查下去发现是整个用户会话的 D-Bus 按需激活全部超时瘫痪,`dbus-broker` 里淤积了 **900MB** 未投递消息,总线连接序号在 1.5 小时内刷到了 17 万+。用 `busctl --user monitor` 数 `Hello` 频率、再挨个 `kill -STOP` 嫌疑进程做排除,最后确认风暴来自 cnmplayer:**播放时每秒稳定产生约 30 条"连上总线 → 查一下 portal → 断开"的短命连接**。

## 根因

两个因素叠加:

1. `SystemVolume::get()/set()` 每次调用都 `Mixer::new("default")` 重新打开一次 ALSA mixer,用完即丢;
2. 主循环每帧(动画时 ~30fps)都会轮询一次音量。

在 PipeWire 系统上,ALSA 的 `default` 走 pipewire-alsa 插件,**每次打开 mixer 都会新建一个 PipeWire 客户端上下文**,而上下文初始化会做一套 RTKit 实时优先级探测:新建 D-Bus 连接 → `NameHasOwner("org.freedesktop.portal.Desktop")` → 读 `portal.Realtime` 三个属性 → 断开。于是 30fps × 每帧一次 = 每秒 30 条新连接。每条连接的出现/消失还会向所有订阅者广播 `NameOwnerChanged`,长时间挂机就把 broker 的队列灌爆了。

这个行为在所有 PipeWire 发行版上都存在,只是多数环境门户查询秒回、没到炸掉的程度——但连接风暴本身一直在白烧 CPU。

## 修复方式

改成 alsamixer 的标准用法:`try_new()` 时打开一次 mixer 缓存进结构体,`get()/set()` 复用句柄,读取前用 `handle_events()` 消化事件保证值是新的(外部改音量也能正常感知)。

实测(`busctl --user monitor` 统计 Hello 数):

| | 启动阶段 | 播放稳态 |
|---|---|---|
| 修复前 | ~5 条 | **~30 条/秒**,持续不断 |
| 修复后 | 6 条(音频栈一次性初始化) | **0 条** |

## 一个需要说明的边界情况

语义上有个小变化:如果 `default` ctl 设备中途消失(裸 ALSA + 拔掉 USB 声卡这类场景),旧代码每次重开能自动恢复,新代码会一直报错直到重启播放器。在 PipeWire/PulseAudio 下 `default` 是稳定的虚拟设备,不受影响。如果你觉得有必要,我可以再补一个出错时重开句柄的兜底逻辑,告诉我就行。

复现方法(修复前):在任何 PipeWire 发行版上播放歌曲,另开终端跑 `busctl --user monitor | grep -c Hello`,几秒就能看到计数狂涨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
