### PR TITLE
v0.5.2: PCM 示波器与 cloudsearch 搜索

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnmplayer"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "compio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cnmplayer"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 
 [features]

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -339,7 +339,7 @@ impl ApiState {
             .param("type", &search_type.to_string())
             .param("limit", &limit.max(1).to_string())
             .param("offset", &offset.to_string());
-        let response = self.client.search(&query).await?;
+        let response = self.client.cloudsearch(&query).await?;
         Ok(response)
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -16,6 +16,7 @@ use crate::render::cover_renderer::render_cover_ascii;
 use crate::render::graphics_overlay::cover_viewport;
 use crate::tmplayer::app::state::LyricLine;
 use crate::tmplayer::audio::cava::{CavaChannels, CavaConfig, MiniCavaState};
+use crate::tmplayer::audio::pcm_tap::PcmRing;
 use crate::tmplayer::playback::metadata::{parse_lrc, parse_plain_lyrics};
 use crate::ui::theme::Theme;
 use anyhow::{Result, anyhow};
@@ -2309,6 +2310,11 @@ impl App {
         self.cava.as_ref().map(|x| x.bars()).unwrap_or_default()
     }
 
+    /// 播放链路上的 PCM 抽头环句柄，经 `HostPlaybackBridge` 交给全屏页示波器。
+    pub fn pcm_ring(&self) -> Arc<PcmRing> {
+        self.audio_player.pcm_ring()
+    }
+
     pub fn main_spectrum_braille(&mut self) -> String {
         let mut out = String::with_capacity(10);
         for i in 0..10 {
@@ -4478,13 +4484,8 @@ impl App {
 
         match self.settings_playback_selected {
             0 => {
-                if crate::tmplayer::audio::cava::is_available() {
-                    self.config.visualize = self.config.visualize.cycle(delta);
-                    let _ = self.config.save();
-                } else if self.config.visualize != crate::data::config::VisualizeMode::Off {
-                    self.config.visualize = crate::data::config::VisualizeMode::Off;
-                    let _ = self.config.save();
-                }
+                self.config.visualize = self.config.visualize.cycle(delta);
+                let _ = self.config.save();
             }
             1 => {
                 self.config.super_smooth_bar = !self.config.super_smooth_bar;

--- a/src/app/player.rs
+++ b/src/app/player.rs
@@ -2,6 +2,7 @@ use crate::STORAGE;
 use crate::app::streaming::{StreamingReader, StreamingReaderHandle};
 use crate::data::config::{CacheCleanStrategy, Config};
 use crate::tmplayer::app::state::{EQ_BANDS, EQ_FREQS_HZ, EqSettings};
+use crate::tmplayer::audio::pcm_tap::{PcmRing, PcmTap};
 use anyhow::{Context, Result};
 use rodio::cpal::Error;
 use rodio::decoder::DecoderBuilder;
@@ -37,6 +38,9 @@ pub struct AudioPlayer {
     progress_rx: Option<Receiver<(u64, u64)>>,
     seek_state: Arc<Mutex<SeekState>>,
     stream_handle: Option<StreamingReaderHandle>,
+    /// PCM 时域抽头：`EqSource` 逐样本写入，全屏页示波器读取。
+    /// 环的寿命长于单个 `EqSource`，故切歌与跳转时必须显式重置。
+    pcm_ring: Arc<PcmRing>,
     /// 切歌时若有未完成的跳转，下次 clear_and_play 需要用归零 seek 使其失效
     invalidate_seek_on_next_play: bool,
 }
@@ -86,6 +90,8 @@ impl AudioPlayer {
         let had_pending_seek = self.invalidate_seek_on_next_play
             || self.seek_state.lock().unwrap().pending_target.is_some();
         self.player.stop();
+        // 环内还是上一首的样本；不清掉的话示波器会先画一段前一首的波形。
+        self.pcm_ring.reset();
         self.player.append(src);
         self.player.play();
         if had_pending_seek {
@@ -127,6 +133,7 @@ impl AudioPlayer {
             progress_rx: None,
             seek_state: Arc::new(Mutex::new(SeekState::default())),
             stream_handle: None,
+            pcm_ring: Arc::new(PcmRing::new()),
             invalidate_seek_on_next_play: false,
         };
 
@@ -139,12 +146,17 @@ impl AudioPlayer {
         self.cache_dir.join(name)
     }
 
+    /// 共享 PCM 抽头环的句柄，供全屏页示波器读取真实波形。
+    pub fn pcm_ring(&self) -> Arc<PcmRing> {
+        self.pcm_ring.clone()
+    }
+
     pub fn play_from_file(&mut self, file_path: &PathBuf) -> Result<()> {
         let file = File::open(file_path)?;
         let builder = DecoderBuilder::new().with_byte_len(file.metadata()?.len());
         let decoder = builder.with_data(BufReader::new(file)).build()?;
         let total_duration = decoder.total_duration();
-        let source = EqSource::new(decoder, self.eq_params.clone());
+        let source = EqSource::new(decoder, self.eq_params.clone(), self.pcm_ring.clone());
         self.clear_and_play(source)?;
         self.stream_handle = None;
         self.total_duration = total_duration;
@@ -162,7 +174,7 @@ impl AudioPlayer {
         let f = move || builder.with_data(BufReader::new(reader)).build();
         let decoder = compio::runtime::spawn_blocking(f).await.unwrap()?;
         let total_duration = decoder.total_duration();
-        let source = EqSource::new(decoder, self.eq_params.clone());
+        let source = EqSource::new(decoder, self.eq_params.clone(), self.pcm_ring.clone());
         self.clear_and_play(source)?;
         self.stream_handle = Some(stream_handle);
         self.total_duration = total_duration;
@@ -204,6 +216,8 @@ impl AudioPlayer {
             handle.cancel();
         }
         self.player.stop();
+        // 停止后环若不清，示波器会一直冻在最后一段波形上。
+        self.pcm_ring.reset();
         self.progress_rx = None;
         self.total_duration = None;
         // 丢弃未完成的跳转：切歌后旧的 seek 结果不再有意义
@@ -378,15 +392,17 @@ where
     last_db_x10: [i32; EQ_BANDS],
     coeffs: [BiquadCoeffs; EQ_BANDS],
     states: Vec<BiquadState>,
+    tap: PcmTap,
 }
 
 impl<S> EqSource<S>
 where
     S: Source<Item = f32>,
 {
-    fn new(inner: S, params: Arc<EqParams>) -> Self {
+    fn new(inner: S, params: Arc<EqParams>, pcm_ring: Arc<PcmRing>) -> Self {
         let channels = inner.channels();
-        let fs = inner.sample_rate().get() as f32;
+        let sample_rate = inner.sample_rate().get();
+        let fs = sample_rate as f32;
         let eq_db = params.load_db();
         let last_db_x10 = params.load_db_x10();
         let coeffs =
@@ -401,6 +417,7 @@ where
             last_db_x10,
             coeffs,
             states,
+            tap: PcmTap::new(pcm_ring, channels.get() as usize, sample_rate),
         }
     }
 
@@ -435,6 +452,9 @@ where
             let state_idx = self.state_index(channel, band);
             output = biquad_process(&self.coeffs[band], &mut self.states[state_idx], output);
         }
+        // PCM 抽头取 EQ 之后、音量之前的样本：波形反映均衡效果，但不随音量缩放。
+        // 逐样本只写一次暂存数组，攒够一批才落环（见 pcm_tap 的线程模型说明）。
+        self.tap.push_sample(channel, output);
         Some(output)
     }
 }
@@ -463,6 +483,8 @@ where
         for state in &mut self.states {
             *state = BiquadState::default();
         }
+        // 环里是跳转前那一段的样本，留着会让示波器先闪一下旧波形。
+        self.tap.reset();
         self.inner.try_seek(pos)
     }
 }

--- a/src/app/player.rs
+++ b/src/app/player.rs
@@ -216,8 +216,8 @@ impl AudioPlayer {
             handle.cancel();
         }
         self.player.stop();
-        // 停止后环若不清，示波器会一直冻在最后一段波形上。
-        self.pcm_ring.reset();
+        // 这里刻意不清 PCM 环：停止后示波器要靠这段残留把波形缓动收回中线。
+        // 换歌不会漏看上一首——所有播放入口都经 clear_and_play，那里会清。
         self.progress_rx = None;
         self.total_duration = None;
         // 丢弃未完成的跳转：切歌后旧的 seek 结果不再有意义

--- a/src/data/config.rs
+++ b/src/data/config.rs
@@ -238,6 +238,17 @@ pub enum VisualizeMode {
 }
 
 impl VisualizeMode {
+    /// 该模式是否依赖 cava 的频谱数据。示波器读播放链路上的 PCM 抽头，不需要。
+    pub fn needs_cava(self) -> bool {
+        matches!(self, VisualizeMode::Bars)
+    }
+
+    /// 数据源就绪，可供用户选中。
+    pub fn is_available(self) -> bool {
+        !self.needs_cava() || crate::tmplayer::audio::cava::is_available()
+    }
+
+    /// 切到下一个**可用**模式：数据源缺失的模式被跳过，而不是让整项无法调整。
     pub fn cycle(self, delta: i32) -> Self {
         const MODES: [VisualizeMode; 3] = [
             VisualizeMode::Off,
@@ -245,9 +256,13 @@ impl VisualizeMode {
             VisualizeMode::Oscilloscope,
         ];
 
-        let index = MODES.iter().position(|mode| *mode == self).unwrap_or(1) as i32;
-        let next = (index + delta).rem_euclid(MODES.len() as i32) as usize;
-        MODES[next]
+        let len = MODES.len() as i32;
+        let step = if delta < 0 { -1 } else { 1 };
+        let start = MODES.iter().position(|mode| *mode == self).unwrap_or(1) as i32;
+        (1..=len)
+            .map(|offset| MODES[(start + step * offset).rem_euclid(len) as usize])
+            .find(|mode| mode.is_available())
+            .unwrap_or(self)
     }
 }
 
@@ -365,7 +380,8 @@ fn default_visualize() -> VisualizeMode {
     if crate::tmplayer::audio::cava::is_available() {
         VisualizeMode::Bars
     } else {
-        VisualizeMode::Off
+        // 示波器不依赖 cava，比直接关掉可视化更有用。
+        VisualizeMode::Oscilloscope
     }
 }
 
@@ -575,10 +591,11 @@ impl Config {
             cfg.spectrum_hz = 30;
         }
 
-        let mut forced_visualize_off = false;
-        if !crate::tmplayer::audio::cava::is_available() && cfg.visualize != VisualizeMode::Off {
-            cfg.visualize = VisualizeMode::Off;
-            forced_visualize_off = true;
+        let mut forced_visualize_fallback = false;
+        if !cfg.visualize.is_available() {
+            // 只有依赖 cava 的模式会落到这里；退到同样无需外部进程的示波器。
+            cfg.visualize = VisualizeMode::Oscilloscope;
+            forced_visualize_fallback = true;
         }
 
         let mut migrated_legacy_sidebar = false;
@@ -608,7 +625,7 @@ impl Config {
             || !raw.contains("keybind_page_up")
             || !raw.contains("keybind_page_down")
             || !raw.contains("keybind_prev")
-            || forced_visualize_off
+            || forced_visualize_fallback
             || !raw.contains("keybind_next")
             || !raw.contains("keybind_toggle_play_pause")
             || !raw.contains("keybind_toggle_mode")

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,10 @@ impl tmplayer::HostPlaybackBridge for AppFullscreenBridge<'_> {
         }
     }
 
+    fn pcm_ring(&self) -> std::sync::Arc<tmplayer::audio::pcm_tap::PcmRing> {
+        self.app.pcm_ring()
+    }
+
     fn snapshot(&mut self) -> tmplayer::HostPlaybackSnapshot {
         let snapshot = self.app.fullscreen_playback_snapshot();
 

--- a/src/tmplayer/app/event_loop.rs
+++ b/src/tmplayer/app/event_loop.rs
@@ -33,20 +33,15 @@ fn sync_playlists_when_viewing_playback(app: &mut AppState) {
 }
 
 fn clear_spectrum(app: &mut AppState) {
-    let bar_len = app.spectrum.bars.len().max(1);
-    app.spectrum.bars = vec![0.0; bar_len];
-    app.spectrum.bars_left = vec![0.0; bar_len];
-    app.spectrum.bars_right = vec![0.0; bar_len];
-    app.spectrum.stereo_left = [0.0; 64];
-    app.spectrum.stereo_right = [0.0; 64];
+    app.spectrum.bars.fill(0.0);
+    app.spectrum.bars_left.fill(0.0);
+    app.spectrum.bars_right.fill(0.0);
 }
 
 fn has_spectrum_data(app: &AppState) -> bool {
     app.spectrum.bars.iter().any(|&v| v > 0.0)
         || app.spectrum.bars_left.iter().any(|&v| v > 0.0)
         || app.spectrum.bars_right.iter().any(|&v| v > 0.0)
-        || app.spectrum.stereo_left.iter().any(|&v| v > 0.0)
-        || app.spectrum.stereo_right.iter().any(|&v| v > 0.0)
 }
 
 fn map_host_state(state: HostPlaybackState) -> PlaybackState {
@@ -502,6 +497,9 @@ pub async fn run(
 
     let mut last_layout = UiLayout::default();
 
+    // 示波器读宿主播放链路上的 PCM 抽头环。独立运行（无宿主）时为空，只画中线。
+    app.pcm_ring = host_bridge.as_ref().map(|bridge| bridge.pcm_ring());
+
     // Initialize cava with the current desired config (best-effort).
     ensure_cava(
         &mut cava,
@@ -566,52 +564,28 @@ pub async fn run(
             ensure_bar_buffers(app, bars);
         }
 
-        // spectrum update
-        if app.config.visualize == VisualizeMode::Off {
-            if has_spectrum_data(app) {
-                clear_spectrum(app);
+        // 频谱采集。示波器不走这里 —— 它在渲染时直接读 PCM 抽头环。但残留的
+        // cava 数据会让 has_spectrum_tail_motion() 长期为真，暂停后仍按高帧率
+        // 空转，所以切走时必须清零。
+        if app.config.visualize.needs_cava() {
+            let period = Duration::from_millis((1000 / app.config.spectrum_hz.max(1)) as u64);
+            if frame_start.duration_since(last_spectrum) >= period {
+                last_spectrum = frame_start;
                 state_changed = true;
-            }
-        } else if frame_start.duration_since(last_spectrum)
-            >= Duration::from_millis((1000 / app.config.spectrum_hz.max(1)) as u64)
-        {
-            last_spectrum = frame_start;
-            state_changed = true;
-
-            match app.config.visualize {
-                VisualizeMode::Off => clear_spectrum(app),
-                VisualizeMode::Bars => {
-                    if let Some(c) = cava.as_ref() {
+                match cava.as_ref() {
+                    Some(c) => {
                         let (l, r) = c.latest_stereo_bars();
                         app.spectrum.bars_left = l;
                         app.spectrum.bars_right = r;
                         let raw = c.latest_bars();
                         app.spectrum.bars = app.spectrum_bar_smoother.apply(&raw);
-                    } else {
-                        clear_spectrum(app);
                     }
-                }
-                VisualizeMode::Oscilloscope => {
-                    if let Some(c) = cava.as_ref() {
-                        let (l, r) = c.latest_stereo_bars();
-                        fill_fixed_bars(&mut app.spectrum.stereo_left, &l);
-                        fill_fixed_bars(&mut app.spectrum.stereo_right, &r);
-                        app.spectrum.bars = c.latest_bars();
-                    } else {
-                        clear_spectrum(app);
-                    }
-
-                    let dt = 1.0 / app.config.spectrum_hz.max(1) as f32;
-                    crate::tmplayer::render::oscilloscope_renderer::advance_phases(
-                        &mut app.spectrum.osc_phase_left,
-                        dt,
-                    );
-                    crate::tmplayer::render::oscilloscope_renderer::advance_phases(
-                        &mut app.spectrum.osc_phase_right,
-                        dt,
-                    );
+                    None => clear_spectrum(app),
                 }
             }
+        } else if has_spectrum_data(app) {
+            clear_spectrum(app);
+            state_changed = true;
         }
 
         if app.player.mode == PlayMode::Idle
@@ -872,15 +846,8 @@ async fn handle_action(
             },
             Overlay::BarSettingsModal => match app.bar_settings_selected {
                 0 => {
-                    if crate::tmplayer::audio::cava::is_available() {
-                        app.config.visualize = app.config.visualize.cycle(1);
-                        save_and_sync_host_config(app, host_bridge).await;
-                    } else if app.config.visualize
-                        != crate::tmplayer::data::config::VisualizeMode::Off
-                    {
-                        app.config.visualize = crate::tmplayer::data::config::VisualizeMode::Off;
-                        save_and_sync_host_config(app, host_bridge).await;
-                    }
+                    app.config.visualize = app.config.visualize.cycle(1);
+                    save_and_sync_host_config(app, host_bridge).await;
                 }
                 1 => {
                     app.config.super_smooth_bar = !app.config.super_smooth_bar;
@@ -1039,10 +1006,8 @@ async fn handle_action(
             } else if app.overlay == Overlay::BarSettingsModal {
                 match app.bar_settings_selected {
                     0 => {
-                        if crate::tmplayer::audio::cava::is_available() {
-                            app.config.visualize = app.config.visualize.cycle(-1);
-                            save_and_sync_host_config(app, host_bridge).await;
-                        }
+                        app.config.visualize = app.config.visualize.cycle(-1);
+                        save_and_sync_host_config(app, host_bridge).await;
                     }
                     1 => {
                         app.config.super_smooth_bar = !app.config.super_smooth_bar;
@@ -1096,10 +1061,8 @@ async fn handle_action(
             } else if app.overlay == Overlay::BarSettingsModal {
                 match app.bar_settings_selected {
                     0 => {
-                        if crate::tmplayer::audio::cava::is_available() {
-                            app.config.visualize = app.config.visualize.cycle(1);
-                            save_and_sync_host_config(app, host_bridge).await;
-                        }
+                        app.config.visualize = app.config.visualize.cycle(1);
+                        save_and_sync_host_config(app, host_bridge).await;
                     }
                     1 => {
                         app.config.super_smooth_bar = !app.config.super_smooth_bar;
@@ -1493,24 +1456,15 @@ fn desired_bar_count(app: &AppState, layout: &UiLayout) -> usize {
 }
 
 fn desired_cava_config(app: &AppState, layout: &UiLayout) -> Option<CavaConfig> {
-    match app.config.visualize {
-        VisualizeMode::Off => None,
-        VisualizeMode::Bars => Some({
-            let bars = desired_bar_count(app, layout);
-            CavaConfig {
-                framerate_hz: app.config.spectrum_hz,
-                bars,
-                channels: CavaChannels::Mono,
-                reverse: app.config.bar_channel_reverse,
-            }
-        }),
-        VisualizeMode::Oscilloscope => Some(CavaConfig {
-            framerate_hz: app.config.spectrum_hz,
-            bars: 64,
-            channels: CavaChannels::Mono,
-            reverse: app.config.bar_channel_reverse,
-        }),
+    if !app.config.visualize.needs_cava() {
+        return None;
     }
+    Some(CavaConfig {
+        framerate_hz: app.config.spectrum_hz,
+        bars: desired_bar_count(app, layout),
+        channels: CavaChannels::Mono,
+        reverse: app.config.bar_channel_reverse,
+    })
 }
 
 fn ensure_cava(
@@ -1563,12 +1517,6 @@ fn max_display_bars(width_cells: u16, gap: bool) -> usize {
         w.div_ceil(2).max(1)
     } else {
         (w / 2).max(1)
-    }
-}
-
-fn fill_fixed_bars(dst: &mut [f32; 64], src: &[f32]) {
-    for i in 0..64 {
-        dst[i] = src.get(i).copied().unwrap_or(0.0);
     }
 }
 

--- a/src/tmplayer/app/state.rs
+++ b/src/tmplayer/app/state.rs
@@ -183,45 +183,126 @@ impl Default for SpectrumData {
     }
 }
 
-/// 暂停或停止后，波形缓动收回中线的时长。
-const SCOPE_SETTLE_DURATION: Duration = Duration::from_millis(420);
+/// cava 的平滑基准帧率，即其 `framerate_mod = 66 / framerate` 里的 66。
+const CAVA_REFERENCE_HZ: f32 = 66.0;
 
-/// 示波器的幅度包络。
+/// cava 默认的 `noise_reduction`（`config.c` 取 77 后除以 100）。
+const CAVA_NOISE_REDUCTION: f32 = 0.77;
+
+/// cava 每帧给 `cava_fall` 的增量（`cavacore.c`: `p->cava_fall[n] += 0.028`）。
+const CAVA_FALL_STEP: f32 = 0.028;
+
+/// 包络推进所依据的帧率。实际帧间隔用 `dt` 换算到这个基准，因此掉帧时动画仍
+/// 按时间走，不会随帧率变快变慢。
+const SCOPE_REFERENCE_HZ: f32 = 60.0;
+
+/// 视作已经到位的残差。指数逼近永远到不了端点，差到这一步就直接钳住。
+///
+/// 1/255 ≈ 一个 8 位色阶，也小于半个盲文子行在任何实际面板高度下的占比，
+/// 因此这一步钳位在视觉上不可见。
+const SCOPE_SETTLED_EPSILON: f32 = 1.0 / 255.0;
+
+/// 示波器的幅度包络：波形样本在绘制前统一乘上它。
 ///
 /// rodio 暂停时直接产出静音、不再拉取解码器，PCM 环因此停更，波形会僵在最后
-/// 一帧。这里给它一条收尾动画：播放中恒为 1，暂停或停止后缓动到 0，波形平滑
-/// 收拢到中线。恢复播放立即回满——环里随即就有新样本，渐入只会显得迟钝。
+/// 一帧。这里把 cava 的两级平滑（`cavacore.c` 的 `process [smoothing]`）搬过来
+/// 接管两端 —— 频谱条走的就是这套，观感因此同源：
+///
+/// - **起振**（cava 的 `integral`）：`out = mem·nr/integral_mod + raw`。输入恒定
+///   时这是个几何级数，等价于一阶滞后：每帧朝目标前进固定比例。
+/// - **回落**（cava 的 `falloff`）：`out = peak·(1 − fall²·gravity_mod)`，`fall`
+///   随时间线性增长 —— 自由落体，位移正比于时间平方。
+///
+/// 为什么回落不能用指数衰减：指数首帧就掉 35%、三帧只剩 27%，在几百毫秒的尺度
+/// 上看起来就是瞬间归零，根本看不出动画。自由落体前几帧几乎不动
+/// （1.0 → 0.96），跌落集中在后半段，这才是"回落"该有的样子。
+///
+/// 包络是**全局**的，不按列分开：所有盲文列同乘一个系数，于是归零发生在同一
+/// 瞬间，全部列同时落到垂直居中位置。按列各自衰减会让它们先后到位。
+///
+/// 归零不代表不画：幅度为 0 时波形退化成居中那条直线，那条线就是波形本身，
+/// 没有独立的中线元素。
 #[derive(Debug, Default)]
 pub struct ScopeGain {
     current: f32,
-    settle_started_at: Option<Instant>,
+    /// 回落起点的幅度，对应 cava 的 `cava_peak`。
+    peak: f32,
+    /// 已下落的时长，对应 cava 逐帧累加的 `cava_fall`。累的是时间而不是帧数，
+    /// 因此掉帧时落点不变。
+    fallen: Duration,
+    animating: bool,
 }
 
 impl ScopeGain {
-    fn tick(&mut self, playing: bool, now: Instant) {
+    /// cava `integral` 的记忆保留系数 `noise_reduction / integral_mod`。
+    fn integral_retention() -> f32 {
+        let framerate_mod = CAVA_REFERENCE_HZ / SCOPE_REFERENCE_HZ;
+        CAVA_NOISE_REDUCTION / framerate_mod.powf(0.1)
+    }
+
+    /// cava `falloff` 的 `gravity_mod`。
+    fn gravity() -> f32 {
+        let framerate_mod = CAVA_REFERENCE_HZ / SCOPE_REFERENCE_HZ;
+        framerate_mod.powf(2.5) * 2.0 / CAVA_NOISE_REDUCTION
+    }
+
+    fn tick(&mut self, playing: bool, dt: Duration) {
         if playing {
+            self.rise(dt);
+        } else {
+            self.fall(dt);
+        }
+    }
+
+    /// 起振：cava 的 integral。几何级数的归一化形式即一阶滞后，残差每帧乘
+    /// `retention`；按 `dt` 取幂，掉帧时到位时刻不变。
+    fn rise(&mut self, dt: Duration) {
+        // 重新起振即取消下落：下次下落从当时的幅度重新起算。
+        self.peak = 0.0;
+        self.fallen = Duration::ZERO;
+
+        if self.current >= 1.0 {
+            self.animating = false;
+            return;
+        }
+        self.animating = true;
+
+        let frames = dt.as_secs_f32() * SCOPE_REFERENCE_HZ;
+        let remaining = (1.0 - self.current) * Self::integral_retention().powf(frames);
+        self.current = 1.0 - remaining;
+
+        if remaining <= SCOPE_SETTLED_EPSILON {
             self.current = 1.0;
-            self.settle_started_at = None;
+            self.animating = false;
+        }
+    }
+
+    /// 回落：cava 的 falloff，位移正比于已下落时长的平方。
+    fn fall(&mut self, dt: Duration) {
+        if self.current <= 0.0 {
+            self.animating = false;
             return;
         }
 
-        match self.settle_started_at {
-            // 归零那一帧已经画出去了，现在才停掉重绘。若和归零放在同一帧，
-            // 重绘会先一步停掉，屏幕就停在收尾前的最后一丝残影上。
-            Some(_) if self.current <= 0.0 => self.settle_started_at = None,
-            Some(started_at) => {
-                let elapsed = now.saturating_duration_since(started_at);
-                let t = elapsed.as_secs_f32() / SCOPE_SETTLE_DURATION.as_secs_f32();
-                self.current = if t >= 1.0 {
-                    0.0
-                } else {
-                    // 收尾总是从满幅起步：恢复播放是瞬时的，没有停在半幅的中间态。
-                    1.0 - cubic_bezier_y(t, 0.0, 0.7)
-                };
-            }
-            // 刚从播放切过来：锚定起点，本帧仍按满幅画。
-            None if self.current > 0.0 => self.settle_started_at = Some(now),
-            None => {}
+        if self.peak <= 0.0 {
+            // 下落的第一帧：锚定峰值，本帧仍按当前幅度画 —— cava 同样是先记
+            // `cava_peak`、下一帧才开始扣。
+            self.peak = self.current;
+        }
+        self.animating = true;
+
+        // cava 每帧 `fall += FALL_STEP`，故 fall = 帧数 × step。这里用时间换算
+        // 帧数，得到与帧率无关的同一条抛物线。
+        self.fallen += dt;
+        let fall = self.fallen.as_secs_f32() * SCOPE_REFERENCE_HZ * CAVA_FALL_STEP;
+        self.current = self.peak * (1.0 - fall * fall * Self::gravity());
+
+        if self.current < SCOPE_SETTLED_EPSILON {
+            // 落平：波形收成居中的直线，动画到此结束。
+            self.current = 0.0;
+            self.peak = 0.0;
+            self.fallen = Duration::ZERO;
+            self.animating = false;
         }
     }
 
@@ -230,8 +311,8 @@ impl ScopeGain {
         self.current
     }
 
-    fn is_settling(&self) -> bool {
-        self.settle_started_at.is_some()
+    fn is_animating(&self) -> bool {
+        self.animating
     }
 }
 
@@ -511,6 +592,8 @@ impl AppState {
     }
 
     pub fn tick(&mut self, now: Instant) {
+        // 必须在覆盖 last_frame 之前取，否则帧间隔恒为 0。
+        let dt = now.saturating_duration_since(self.last_frame);
         self.last_frame = now;
 
         if !self.cover_render_inflight.borrow().is_empty() {
@@ -552,7 +635,7 @@ impl AppState {
 
         self.tick_playlist_slide(now);
         self.scope_gain
-            .tick(self.player.playback == PlaybackState::Playing, now);
+            .tick(self.player.playback == PlaybackState::Playing, dt);
     }
 
     /// 启动一次侧边栏滑入/滑出。记录当前位置作为起点，因此支持动画中途反向。
@@ -605,7 +688,7 @@ impl AppState {
             return true;
         }
 
-        if self.scope_is_settling() {
+        if self.scope_is_animating() {
             return true;
         }
 
@@ -640,7 +723,7 @@ impl AppState {
                         && self.has_spectrum_tail_motion())
             }
             VisualizeMode::Oscilloscope => {
-                self.player.playback == PlaybackState::Playing || self.scope_gain.is_settling()
+                self.player.playback == PlaybackState::Playing || self.scope_gain.is_animating()
             }
         };
 
@@ -661,12 +744,12 @@ impl AppState {
             || self.spectrum.bars_right.iter().any(|&v| v > TAIL_EPS)
     }
 
-    /// 示波器正在把波形收回中线，需要持续重绘把这段动画推完。
-    fn scope_is_settling(&self) -> bool {
+    /// 示波器的包络动画（起振或回落）正在进行，需要持续重绘把它推完。
+    fn scope_is_animating(&self) -> bool {
         matches!(
             self.config.visualize,
             crate::tmplayer::data::config::VisualizeMode::Oscilloscope
-        ) && self.scope_gain.is_settling()
+        ) && self.scope_gain.is_animating()
     }
 
     pub fn start_cover_anim(
@@ -694,77 +777,209 @@ impl AppState {
 mod tests {
     use super::*;
 
+    const FRAME: Duration = Duration::from_millis(1000 / 60);
+
+    /// 一帧一帧跑 cava `cavacore.c` 的两级平滑，作为对照实现。
+    ///
+    /// `raw` 恒定输入；返回归一化到稳态的逐帧输出。cava 的 integral 是个不收敛到
+    /// 1 的几何级数（稳态 `1/(1-k)`），归一化后才能和包络比。
+    fn cava_reference(raw: f32, frames: usize) -> Vec<f32> {
+        let framerate_mod = CAVA_REFERENCE_HZ / SCOPE_REFERENCE_HZ;
+        let gravity_mod = framerate_mod.powf(2.5) * 2.0 / CAVA_NOISE_REDUCTION;
+        let integral_mod = framerate_mod.powf(0.1);
+        let k = CAVA_NOISE_REDUCTION / integral_mod;
+
+        let (mut mem, mut prev, mut peak, mut fall) = (0.0f32, 0.0f32, 0.0f32, 0.0f32);
+        let mut out_series = Vec::with_capacity(frames);
+        for _ in 0..frames {
+            let mut out = raw;
+            if out < prev && CAVA_NOISE_REDUCTION > 0.1 {
+                out = (peak * (1.0 - fall * fall * gravity_mod)).max(0.0);
+                fall += CAVA_FALL_STEP;
+            } else {
+                peak = out;
+                fall = 0.0;
+            }
+            prev = out;
+            out = mem * k + out;
+            mem = out;
+            out_series.push(out * (1.0 - k) / raw);
+        }
+        out_series
+    }
+
+    /// 起振逐帧对齐 cava 的 integral（归一化后）。
     #[test]
-    fn scope_gain_settles_to_zero_and_snaps_back_on_resume() {
+    fn rise_matches_cava_integral() {
+        let reference = cava_reference(1.0, 12);
         let mut gain = ScopeGain::default();
-        let t0 = Instant::now();
 
-        gain.tick(true, t0);
-        assert_eq!(gain.value(), 1.0);
-        assert!(!gain.is_settling());
+        for (frame, expected) in reference.iter().enumerate() {
+            gain.tick(true, Duration::from_secs_f32(1.0 / SCOPE_REFERENCE_HZ));
+            assert!(
+                (gain.value() - expected).abs() < 1.0e-3,
+                "第 {frame} 帧不一致: scope={} cava={expected}",
+                gain.value()
+            );
+        }
+    }
 
-        // 暂停后的第一帧只锚定起点，幅度仍是满的；从下一帧起才开始收。
-        gain.tick(false, t0);
-        assert_eq!(gain.value(), 1.0);
-        assert!(gain.is_settling());
+    /// 起振是一阶滞后：首帧就走掉可观一段，随后逐帧放缓。
+    #[test]
+    fn rise_is_front_loaded_and_decelerates() {
+        let mut gain = ScopeGain::default();
+        assert_eq!(gain.value(), 0.0, "静止态包络为 0，波形是居中直线");
 
-        // 之后必须单调收敛，且全程标记为动画中——否则重绘会被停掉，
-        // 收尾动画只推进一帧就卡住。
-        let mut prev = 1.0;
-        for ms in [1u64, 100, 200, 300, 419] {
-            gain.tick(false, t0 + Duration::from_millis(ms));
-            assert!(gain.value() < prev, "gain must shrink by {ms}ms");
-            assert!(gain.is_settling(), "must stay animating at {ms}ms");
+        let mut steps = Vec::new();
+        let mut prev = 0.0;
+        for _ in 0..8 {
+            gain.tick(true, FRAME);
+            steps.push(gain.value() - prev);
             prev = gain.value();
         }
 
-        gain.tick(false, t0 + SCOPE_SETTLE_DURATION);
-        assert_eq!(gain.value(), 0.0);
-        // 归零这一帧本身还得再画一次，所以此刻仍要求重绘；否则屏幕会停在
-        // 收尾前的最后一丝残影上，直到别处偶然触发重绘才补上。
-        assert!(gain.is_settling());
-
-        gain.tick(
-            false,
-            t0 + SCOPE_SETTLE_DURATION + Duration::from_millis(16),
+        assert!(steps[0] > 0.2, "首帧应明显张开: {}", steps[0]);
+        assert!(
+            steps.windows(2).all(|pair| pair[1] < pair[0]),
+            "步长应逐帧变小: {steps:?}"
         );
-        assert!(!gain.is_settling());
+    }
 
-        // 之后继续 tick 不该再请求重绘。
-        gain.tick(false, t0 + Duration::from_secs(5));
-        assert!(!gain.is_settling());
-
-        gain.tick(true, t0 + Duration::from_secs(6));
+    /// 回落是自由落体：**前段几乎不动**，跌落集中在后半段。
+    ///
+    /// 这条是"看得见回落动画"的判据。换成指数衰减会立刻挂：指数首帧就掉 35%。
+    #[test]
+    fn fall_is_gravity_shaped_not_exponential() {
+        let mut gain = ScopeGain::default();
+        gain.tick(true, Duration::from_secs(1));
         assert_eq!(gain.value(), 1.0);
+
+        let mut values = Vec::new();
+        loop {
+            gain.tick(false, FRAME);
+            values.push(gain.value());
+            if gain.value() == 0.0 || values.len() > 120 {
+                break;
+            }
+        }
+
+        // 起手极慢：第 3 帧还留着九成以上。指数衰减此时只剩 0.27。
+        assert!(values[2] > 0.9, "起手应几乎不动: {}", values[2]);
+        // 过半时间才掉一半左右，而不是早早贴底。
+        let half = values[values.len() / 2];
+        assert!(half > 0.4 && half < 0.85, "中点幅度 {half} 不像自由落体");
+        // 单调下落，且确实落到零。
+        assert!(
+            values.windows(2).all(|pair| pair[1] <= pair[0]),
+            "幅度不得回升: {values:?}"
+        );
+        assert_eq!(*values.last().unwrap(), 0.0);
+    }
+
+    /// 回落逐帧对齐 cava 的 falloff（同一条抛物线）。
+    #[test]
+    fn fall_matches_cava_falloff() {
+        let one_frame = Duration::from_secs_f32(1.0 / SCOPE_REFERENCE_HZ);
+        let framerate_mod = CAVA_REFERENCE_HZ / SCOPE_REFERENCE_HZ;
+        let gravity_mod = framerate_mod.powf(2.5) * 2.0 / CAVA_NOISE_REDUCTION;
+
+        let mut gain = ScopeGain::default();
+        gain.tick(true, Duration::from_secs(1));
+
+        // cava 侧：peak 已锚定为 1.0，fall 从 0 起累加。
+        let mut fall = 0.0f32;
+        for frame in 0..25 {
+            gain.tick(false, one_frame);
+            fall += CAVA_FALL_STEP;
+            let expected = (1.0 - fall * fall * gravity_mod).max(0.0);
+            if expected < SCOPE_SETTLED_EPSILON {
+                assert_eq!(gain.value(), 0.0, "第 {frame} 帧应已落平");
+                break;
+            }
+            assert!(
+                (gain.value() - expected).abs() < 1.0e-3,
+                "第 {frame} 帧不一致: scope={} cava={expected}",
+                gain.value()
+            );
+        }
     }
 
     #[test]
-    fn resuming_mid_settle_restarts_a_full_length_settle() {
+    fn fall_returns_to_flat_and_stops_requesting_redraw() {
         let mut gain = ScopeGain::default();
-        let t0 = Instant::now();
+        gain.tick(true, Duration::from_secs(1));
 
-        gain.tick(true, t0);
-        gain.tick(false, t0 + Duration::from_millis(300));
-        gain.tick(false, t0 + Duration::from_millis(400));
-        assert!(gain.value() < 1.0);
+        // 停止：全程标记为动画中——否则重绘会被停掉，回落只推进一帧就卡住。
+        for frame in 0..40 {
+            gain.tick(false, FRAME);
+            if gain.value() == 0.0 {
+                break;
+            }
+            assert!(gain.is_animating(), "第 {frame} 帧应仍在动画中");
+        }
 
-        gain.tick(true, t0 + Duration::from_millis(410));
-        assert_eq!(gain.value(), 1.0);
+        assert_eq!(gain.value(), 0.0, "应已落平");
+        assert!(!gain.is_animating());
 
-        // 再次暂停：计时从这一刻重新起算。若沿用上一轮起点，下面这帧的
-        // elapsed 会超过整个时长，幅度提前归零。
-        let pause_at = t0 + Duration::from_millis(420);
-        gain.tick(false, pause_at);
-        gain.tick(
-            false,
-            pause_at + SCOPE_SETTLE_DURATION - Duration::from_millis(1),
-        );
-        assert!(
-            gain.value() > 0.0,
-            "settle must restart from the resume point"
-        );
-
-        gain.tick(false, pause_at + SCOPE_SETTLE_DURATION);
+        // 落平后继续 tick 不该再请求重绘。
+        gain.tick(false, FRAME);
+        assert!(!gain.is_animating());
         assert_eq!(gain.value(), 0.0);
+    }
+
+    #[test]
+    fn resuming_mid_fall_ramps_up_from_the_residual_value() {
+        let mut gain = ScopeGain::default();
+        gain.tick(true, Duration::from_secs(1));
+
+        for _ in 0..8 {
+            gain.tick(false, FRAME);
+        }
+        let mid = gain.value();
+        assert!(mid > 0.0 && mid < 1.0, "应处于回落途中: {mid}");
+
+        // 恢复播放从残值继续张开，不跳变、也不从 0 重来。
+        gain.tick(true, FRAME);
+        assert!(
+            gain.value() > mid,
+            "应从残值继续增长: {} vs {mid}",
+            gain.value()
+        );
+
+        // 再次停止：抛物线从这一刻重新起算，而不是接着上一轮的 fallen。
+        gain.tick(false, FRAME);
+        assert!(
+            gain.value() > mid,
+            "重新起算应高于上一轮同期: {} vs {mid}",
+            gain.value()
+        );
+    }
+
+    /// 两端动画都必须与帧率无关：掉帧时按时间补足。
+    #[test]
+    fn envelope_is_frame_rate_independent() {
+        let elapsed = Duration::from_millis(150);
+
+        for playing in [true, false] {
+            let mut fast = ScopeGain::default();
+            let mut slow = ScopeGain::default();
+            if !playing {
+                fast.tick(true, Duration::from_secs(1));
+                slow.tick(true, Duration::from_secs(1));
+            }
+
+            let step = elapsed / 20;
+            for _ in 0..20 {
+                fast.tick(playing, step);
+            }
+            slow.tick(playing, elapsed);
+
+            assert!(
+                (fast.value() - slow.value()).abs() < 1.0e-3,
+                "playing={playing} fast={} slow={}",
+                fast.value(),
+                slow.value()
+            );
+        }
     }
 }

--- a/src/tmplayer/app/state.rs
+++ b/src/tmplayer/app/state.rs
@@ -11,6 +11,7 @@ use crate::tmplayer::ui::theme::Theme;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::sync::mpsc;
 use std::sync::mpsc::{Receiver, Sender, TryRecvError};
 use std::time::{Duration, Instant};
@@ -170,12 +171,6 @@ pub struct SpectrumData {
     pub bars: Vec<f32>,
     pub bars_left: Vec<f32>,
     pub bars_right: Vec<f32>,
-    pub stereo_left: [f32; 64],
-    pub stereo_right: [f32; 64],
-
-    // Oscilloscope synthesis state (kept across frames for stability).
-    pub osc_phase_left: [f32; 64],
-    pub osc_phase_right: [f32; 64],
 }
 
 impl Default for SpectrumData {
@@ -184,10 +179,6 @@ impl Default for SpectrumData {
             bars: vec![0.0; 64],
             bars_left: vec![0.0; 64],
             bars_right: vec![0.0; 64],
-            stereo_left: [0.0; 64],
-            stereo_right: [0.0; 64],
-            osc_phase_left: [0.0; 64],
-            osc_phase_right: [0.0; 64],
         }
     }
 }
@@ -256,6 +247,11 @@ pub struct AppState {
     pub spectrum: SpectrumData,
     pub spectrum_bar_smoother: Ema,
     pub spectrum_render_grid: Vec<Vec<char>>,
+
+    /// 宿主播放链路上的 PCM 抽头环；无宿主（独立全屏）时为 None。
+    pub pcm_ring: Option<Arc<crate::tmplayer::audio::pcm_tap::PcmRing>>,
+    /// 示波器的复用缓冲，渲染路径因此零分配。
+    pub scope: crate::tmplayer::render::oscilloscope_renderer::ScopeScratch,
 
     pub cover_cache: RefCell<CoverCache>,
     pub cover_dominant_rgb_cache: RefCell<HashMap<u64, (u8, u8, u8)>>,
@@ -376,6 +372,8 @@ impl AppState {
             spectrum: SpectrumData::default(),
             spectrum_bar_smoother: Ema::new(0.35, 64),
             spectrum_render_grid: Vec::new(),
+            pcm_ring: None,
+            scope: Default::default(),
             cover_cache: RefCell::new(CoverCache::new(20)),
             cover_dominant_rgb_cache: RefCell::new(HashMap::new()),
             cover_render_tx,

--- a/src/tmplayer/app/state.rs
+++ b/src/tmplayer/app/state.rs
@@ -183,6 +183,58 @@ impl Default for SpectrumData {
     }
 }
 
+/// 暂停或停止后，波形缓动收回中线的时长。
+const SCOPE_SETTLE_DURATION: Duration = Duration::from_millis(420);
+
+/// 示波器的幅度包络。
+///
+/// rodio 暂停时直接产出静音、不再拉取解码器，PCM 环因此停更，波形会僵在最后
+/// 一帧。这里给它一条收尾动画：播放中恒为 1，暂停或停止后缓动到 0，波形平滑
+/// 收拢到中线。恢复播放立即回满——环里随即就有新样本，渐入只会显得迟钝。
+#[derive(Debug, Default)]
+pub struct ScopeGain {
+    current: f32,
+    settle_started_at: Option<Instant>,
+}
+
+impl ScopeGain {
+    fn tick(&mut self, playing: bool, now: Instant) {
+        if playing {
+            self.current = 1.0;
+            self.settle_started_at = None;
+            return;
+        }
+
+        match self.settle_started_at {
+            // 归零那一帧已经画出去了，现在才停掉重绘。若和归零放在同一帧，
+            // 重绘会先一步停掉，屏幕就停在收尾前的最后一丝残影上。
+            Some(_) if self.current <= 0.0 => self.settle_started_at = None,
+            Some(started_at) => {
+                let elapsed = now.saturating_duration_since(started_at);
+                let t = elapsed.as_secs_f32() / SCOPE_SETTLE_DURATION.as_secs_f32();
+                self.current = if t >= 1.0 {
+                    0.0
+                } else {
+                    // 收尾总是从满幅起步：恢复播放是瞬时的，没有停在半幅的中间态。
+                    1.0 - cubic_bezier_y(t, 0.0, 0.7)
+                };
+            }
+            // 刚从播放切过来：锚定起点，本帧仍按满幅画。
+            None if self.current > 0.0 => self.settle_started_at = Some(now),
+            None => {}
+        }
+    }
+
+    /// 当前幅度系数，渲染时乘在样本上。
+    pub fn value(&self) -> f32 {
+        self.current
+    }
+
+    fn is_settling(&self) -> bool {
+        self.settle_started_at.is_some()
+    }
+}
+
 #[derive(Debug)]
 pub struct PlayerState {
     pub mode: PlayMode,
@@ -252,6 +304,8 @@ pub struct AppState {
     pub pcm_ring: Option<Arc<crate::tmplayer::audio::pcm_tap::PcmRing>>,
     /// 示波器的复用缓冲，渲染路径因此零分配。
     pub scope: crate::tmplayer::render::oscilloscope_renderer::ScopeScratch,
+    /// 波形幅度包络，暂停/停止后驱动波形收回中线。
+    pub scope_gain: ScopeGain,
 
     pub cover_cache: RefCell<CoverCache>,
     pub cover_dominant_rgb_cache: RefCell<HashMap<u64, (u8, u8, u8)>>,
@@ -374,6 +428,7 @@ impl AppState {
             spectrum_render_grid: Vec::new(),
             pcm_ring: None,
             scope: Default::default(),
+            scope_gain: ScopeGain::default(),
             cover_cache: RefCell::new(CoverCache::new(20)),
             cover_dominant_rgb_cache: RefCell::new(HashMap::new()),
             cover_render_tx,
@@ -496,6 +551,8 @@ impl AppState {
         }
 
         self.tick_playlist_slide(now);
+        self.scope_gain
+            .tick(self.player.playback == PlaybackState::Playing, now);
     }
 
     /// 启动一次侧边栏滑入/滑出。记录当前位置作为起点，因此支持动画中途反向。
@@ -548,6 +605,10 @@ impl AppState {
             return true;
         }
 
+        if self.scope_is_settling() {
+            return true;
+        }
+
         if self.cover_anim.is_some()
             || self.playlist_album_anim.is_some()
             || self.pending_system_cover_anim.is_some()
@@ -567,27 +628,25 @@ impl AppState {
     }
 
     pub fn active_render_fps(&self) -> u32 {
+        use crate::tmplayer::data::config::VisualizeMode;
+
         let base = self.config.ui_fps.clamp(10, 60);
-        if self.player.playback == PlaybackState::Playing {
-            match self.config.visualize {
-                crate::tmplayer::data::config::VisualizeMode::Off => {}
-                crate::tmplayer::data::config::VisualizeMode::Bars
-                | crate::tmplayer::data::config::VisualizeMode::Oscilloscope => {
-                    return self.config.spectrum_hz.clamp(base, 60);
-                }
+        // 频谱靠 cava 的拖尾衰减，示波器靠自己的收尾动画：暂停后两者都还在动。
+        let visual_active = match self.config.visualize {
+            VisualizeMode::Off => false,
+            VisualizeMode::Bars => {
+                self.player.playback == PlaybackState::Playing
+                    || (self.player.playback == PlaybackState::Paused
+                        && self.has_spectrum_tail_motion())
             }
-        }
-
-        if self.player.playback == PlaybackState::Paused && self.has_spectrum_tail_motion() {
-            match self.config.visualize {
-                crate::tmplayer::data::config::VisualizeMode::Off => {}
-                crate::tmplayer::data::config::VisualizeMode::Bars
-                | crate::tmplayer::data::config::VisualizeMode::Oscilloscope => {
-                    return self.config.spectrum_hz.clamp(base, 60);
-                }
+            VisualizeMode::Oscilloscope => {
+                self.player.playback == PlaybackState::Playing || self.scope_gain.is_settling()
             }
-        }
+        };
 
+        if visual_active {
+            return self.config.spectrum_hz.clamp(base, 60);
+        }
         base
     }
 
@@ -600,6 +659,14 @@ impl AppState {
         self.spectrum.bars.iter().any(|&v| v > TAIL_EPS)
             || self.spectrum.bars_left.iter().any(|&v| v > TAIL_EPS)
             || self.spectrum.bars_right.iter().any(|&v| v > TAIL_EPS)
+    }
+
+    /// 示波器正在把波形收回中线，需要持续重绘把这段动画推完。
+    fn scope_is_settling(&self) -> bool {
+        matches!(
+            self.config.visualize,
+            crate::tmplayer::data::config::VisualizeMode::Oscilloscope
+        ) && self.scope_gain.is_settling()
     }
 
     pub fn start_cover_anim(
@@ -620,5 +687,84 @@ impl AppState {
 
     pub fn close_overlay(&mut self) {
         self.overlay = Overlay::None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scope_gain_settles_to_zero_and_snaps_back_on_resume() {
+        let mut gain = ScopeGain::default();
+        let t0 = Instant::now();
+
+        gain.tick(true, t0);
+        assert_eq!(gain.value(), 1.0);
+        assert!(!gain.is_settling());
+
+        // 暂停后的第一帧只锚定起点，幅度仍是满的；从下一帧起才开始收。
+        gain.tick(false, t0);
+        assert_eq!(gain.value(), 1.0);
+        assert!(gain.is_settling());
+
+        // 之后必须单调收敛，且全程标记为动画中——否则重绘会被停掉，
+        // 收尾动画只推进一帧就卡住。
+        let mut prev = 1.0;
+        for ms in [1u64, 100, 200, 300, 419] {
+            gain.tick(false, t0 + Duration::from_millis(ms));
+            assert!(gain.value() < prev, "gain must shrink by {ms}ms");
+            assert!(gain.is_settling(), "must stay animating at {ms}ms");
+            prev = gain.value();
+        }
+
+        gain.tick(false, t0 + SCOPE_SETTLE_DURATION);
+        assert_eq!(gain.value(), 0.0);
+        // 归零这一帧本身还得再画一次，所以此刻仍要求重绘；否则屏幕会停在
+        // 收尾前的最后一丝残影上，直到别处偶然触发重绘才补上。
+        assert!(gain.is_settling());
+
+        gain.tick(
+            false,
+            t0 + SCOPE_SETTLE_DURATION + Duration::from_millis(16),
+        );
+        assert!(!gain.is_settling());
+
+        // 之后继续 tick 不该再请求重绘。
+        gain.tick(false, t0 + Duration::from_secs(5));
+        assert!(!gain.is_settling());
+
+        gain.tick(true, t0 + Duration::from_secs(6));
+        assert_eq!(gain.value(), 1.0);
+    }
+
+    #[test]
+    fn resuming_mid_settle_restarts_a_full_length_settle() {
+        let mut gain = ScopeGain::default();
+        let t0 = Instant::now();
+
+        gain.tick(true, t0);
+        gain.tick(false, t0 + Duration::from_millis(300));
+        gain.tick(false, t0 + Duration::from_millis(400));
+        assert!(gain.value() < 1.0);
+
+        gain.tick(true, t0 + Duration::from_millis(410));
+        assert_eq!(gain.value(), 1.0);
+
+        // 再次暂停：计时从这一刻重新起算。若沿用上一轮起点，下面这帧的
+        // elapsed 会超过整个时长，幅度提前归零。
+        let pause_at = t0 + Duration::from_millis(420);
+        gain.tick(false, pause_at);
+        gain.tick(
+            false,
+            pause_at + SCOPE_SETTLE_DURATION - Duration::from_millis(1),
+        );
+        assert!(
+            gain.value() > 0.0,
+            "settle must restart from the resume point"
+        );
+
+        gain.tick(false, pause_at + SCOPE_SETTLE_DURATION);
+        assert_eq!(gain.value(), 0.0);
     }
 }

--- a/src/tmplayer/audio/mod.rs
+++ b/src/tmplayer/audio/mod.rs
@@ -1,2 +1,3 @@
 pub mod cava;
+pub mod pcm_tap;
 pub mod smoother;

--- a/src/tmplayer/audio/pcm_tap.rs
+++ b/src/tmplayer/audio/pcm_tap.rs
@@ -140,12 +140,13 @@ impl PcmRing {
     pub fn snapshot(&self, out: &mut PcmSnapshot) {
         out.sample_rate = self.sample_rate.load(Ordering::Relaxed);
 
-        let generation = self.generation.load(Ordering::Acquire);
         let Ok(mut ring) = self.inner.lock() else {
             out.clear();
             return;
         };
-        ring.sync_generation(generation);
+        // 代号必须在锁内读：锁外读会漏掉"读代号之后、取到锁之前"落地的 reset，
+        // 那一帧就会画出跳转前的波形。
+        ring.sync_generation(self.generation.load(Ordering::Acquire));
 
         let len = ring.filled;
         out.len = len;

--- a/src/tmplayer/audio/pcm_tap.rs
+++ b/src/tmplayer/audio/pcm_tap.rs
@@ -251,3 +251,100 @@ impl PcmTap {
         self.len = 0;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn ramp(from: usize, count: usize) -> Vec<f32> {
+        (from..from + count).map(|i| i as f32).collect()
+    }
+
+    #[test]
+    fn snapshot_returns_newest_samples_in_order_across_wrap() {
+        let ring = PcmRing::new();
+        let total = CAPACITY + 777;
+        let data = ramp(0, total);
+        for chunk in data.chunks(FLUSH_FRAMES) {
+            ring.push(chunk, chunk, 48_000);
+        }
+
+        let mut snap = PcmSnapshot::default();
+        ring.snapshot(&mut snap);
+
+        assert_eq!(snap.len, CAPACITY);
+        assert_eq!(snap.sample_rate, 48_000);
+        assert_eq!(snap.left[0], (total - CAPACITY) as f32);
+        assert_eq!(snap.left[CAPACITY - 1], (total - 1) as f32);
+        assert!(snap.left[..snap.len].windows(2).all(|w| w[1] - w[0] == 1.0));
+    }
+
+    #[test]
+    fn reset_empties_the_ring_without_a_further_push() {
+        let ring = PcmRing::new();
+        ring.push(&[0.5; 64], &[0.5; 64], 48_000);
+        ring.reset();
+
+        let mut snap = PcmSnapshot::default();
+        ring.snapshot(&mut snap);
+        assert_eq!(snap.len, 0);
+    }
+
+    #[test]
+    fn identical_channels_are_reported_as_mono() {
+        let ring = PcmRing::new();
+        let left = ramp(0, 128);
+        ring.push(&left, &left, 48_000);
+
+        let mut snap = PcmSnapshot::default();
+        ring.snapshot(&mut snap);
+        assert!(!snap.stereo);
+
+        let mut right = left.clone();
+        right[7] = -1.0;
+        ring.push(&left, &right, 48_000);
+        ring.snapshot(&mut snap);
+        assert!(snap.stereo);
+    }
+
+    #[test]
+    fn tap_splits_stereo_and_mirrors_mono() {
+        let stereo = Arc::new(PcmRing::new());
+        let mut tap = PcmTap::new(Arc::clone(&stereo), 2, 48_000);
+        for (channel, sample) in [(0, 1.0), (1, 2.0), (0, 3.0), (1, 4.0)] {
+            tap.push_sample(channel, sample);
+        }
+        tap.flush();
+
+        let mut snap = PcmSnapshot::default();
+        stereo.snapshot(&mut snap);
+        assert_eq!(snap.len, 2);
+        assert_eq!(&snap.left[..2], &[1.0, 3.0]);
+        assert_eq!(&snap.right[..2], &[2.0, 4.0]);
+
+        let mono = Arc::new(PcmRing::new());
+        let mut tap = PcmTap::new(Arc::clone(&mono), 1, 48_000);
+        tap.push_sample(0, 0.25);
+        tap.flush();
+
+        mono.snapshot(&mut snap);
+        assert_eq!(snap.len, 1);
+        assert_eq!(snap.left[0], snap.right[0]);
+        assert!(!snap.stereo);
+    }
+
+    #[test]
+    fn tap_flushes_on_its_own_once_staging_fills() {
+        let ring = Arc::new(PcmRing::new());
+        let mut tap = PcmTap::new(Arc::clone(&ring), 1, 48_000);
+        for i in 0..FLUSH_FRAMES {
+            tap.push_sample(0, i as f32);
+        }
+
+        // 没有手动 flush：攒满一批就该自动落环。
+        let mut snap = PcmSnapshot::default();
+        ring.snapshot(&mut snap);
+        assert_eq!(snap.len, FLUSH_FRAMES);
+    }
+}

--- a/src/tmplayer/audio/pcm_tap.rs
+++ b/src/tmplayer/audio/pcm_tap.rs
@@ -1,0 +1,253 @@
+//! 播放链路上的 PCM 时域抽头：示波器据此绘制真实波形，而非由频谱反推。
+//!
+//! 线程模型是本模块唯一的设计约束。写侧跑在 cpal 的实时音频回调线程上
+//! （rodio 把整条 `Source` 链逐样本拉取），由此得到三条规则：
+//!
+//! - 写侧**绝不阻塞**：`push` 用 `try_lock`，抢不到锁就整批丢弃。
+//! - 写侧**绝不逐样本取锁**：44.1 kHz 立体声等于每秒 88200 次加锁。调用方
+//!   （`EqSource`）经 [`PcmTap`] 攒满一批再落环，锁频率降到每秒约 86 次。
+//! - 读侧（渲染线程）用阻塞的 `lock`：丢一帧快照会让画面闪空，而多等几微秒
+//!   无人察觉。这个不对称是有意的。
+//!
+//! 丢一批约 12 ms，在可视化上不可感知，故写侧的丢弃策略是安全的。
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+
+/// 环容量（帧）。取 2 的幂以便用掩码回绕。
+///
+/// 8192 帧 ≈ 186 ms @ 44.1 kHz，须同时容纳显示窗口与触发搜索区间
+/// （见 `render::oscilloscope_renderer` 的 `WINDOW_MS` / `TRIGGER_SEARCH_MS`）。
+pub const CAPACITY: usize = 8192;
+const MASK: usize = CAPACITY - 1;
+
+/// 单批帧数：[`PcmTap`] 的暂存容量，也是环的写入粒度。
+///
+/// 512 帧 @ 44.1 kHz ≈ 11.6 ms，远小于显示窗口，故波形"最新端"的滞后不可见；
+/// 又足够大，使加锁频率相对逐样本降低三个数量级。
+const FLUSH_FRAMES: usize = 512;
+
+/// 音频线程与渲染线程之间的共享环形缓冲。
+#[derive(Debug)]
+pub struct PcmRing {
+    inner: Mutex<Ring>,
+    sample_rate: AtomicU32,
+    /// 每次 [`PcmRing::reset`] 自增；两侧发现代号变化即视环为空。
+    /// 这让 `reset` 只是一次原子自增，可以从任意线程（含音频线程）调用。
+    generation: AtomicU64,
+}
+
+#[derive(Debug)]
+struct Ring {
+    left: Box<[f32]>,
+    right: Box<[f32]>,
+    /// 下一个写入下标
+    pos: usize,
+    /// 有效帧数，上限 [`CAPACITY`]
+    filled: usize,
+    generation: u64,
+}
+
+impl Ring {
+    /// 代号变化说明期间发生过 `reset`：丢弃全部内容。
+    /// 无需清零样本数组 —— `filled` 已界定有效范围。
+    fn sync_generation(&mut self, generation: u64) {
+        if self.generation != generation {
+            self.generation = generation;
+            self.pos = 0;
+            self.filled = 0;
+        }
+    }
+}
+
+/// 线性化后的快照，最旧样本在前。调用方复用同一实例，渲染路径因此零分配。
+#[derive(Debug)]
+pub struct PcmSnapshot {
+    /// 仅前 `len` 个元素有效
+    pub left: Vec<f32>,
+    pub right: Vec<f32>,
+    pub len: usize,
+    pub sample_rate: u32,
+    /// 左右声道确有差异。单声道音源为 `false`，渲染侧据此跳过右声道，
+    /// 避免把同一条曲线画两遍。
+    pub stereo: bool,
+}
+
+impl Default for PcmSnapshot {
+    fn default() -> Self {
+        Self {
+            left: vec![0.0; CAPACITY],
+            right: vec![0.0; CAPACITY],
+            len: 0,
+            sample_rate: 0,
+            stereo: false,
+        }
+    }
+}
+
+impl PcmSnapshot {
+    pub fn clear(&mut self) {
+        self.len = 0;
+        self.stereo = false;
+    }
+}
+
+impl PcmRing {
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(Ring {
+                left: vec![0.0; CAPACITY].into_boxed_slice(),
+                right: vec![0.0; CAPACITY].into_boxed_slice(),
+                pos: 0,
+                filled: 0,
+                generation: 0,
+            }),
+            sample_rate: AtomicU32::new(0),
+            generation: AtomicU64::new(0),
+        }
+    }
+
+    /// 丢弃环内全部样本。切歌与跳转后必须调用，否则示波器会画出上一段音频。
+    pub fn reset(&self) {
+        self.generation.fetch_add(1, Ordering::Release);
+    }
+
+    /// 写入一批帧，`left` 与 `right` 按较短者对齐。抢不到锁则整批丢弃。
+    pub fn push(&self, left: &[f32], right: &[f32], sample_rate: u32) {
+        let count = left.len().min(right.len());
+        if count == 0 {
+            return;
+        }
+        self.sample_rate.store(sample_rate, Ordering::Relaxed);
+
+        let Ok(mut ring) = self.inner.try_lock() else {
+            return;
+        };
+        ring.sync_generation(self.generation.load(Ordering::Acquire));
+
+        // 单批超过容量时只保留最新一段：更早的部分本就会被同一批覆盖。
+        let skip = count.saturating_sub(CAPACITY);
+        let pos = ring.pos;
+        write_wrapping(&mut ring.left, pos, &left[skip..count]);
+        write_wrapping(&mut ring.right, pos, &right[skip..count]);
+
+        let written = count - skip;
+        ring.pos = (pos + written) & MASK;
+        ring.filled = (ring.filled + written).min(CAPACITY);
+    }
+
+    /// 把环线性化进 `out`。渲染线程调用，允许短暂阻塞。
+    pub fn snapshot(&self, out: &mut PcmSnapshot) {
+        out.sample_rate = self.sample_rate.load(Ordering::Relaxed);
+
+        let generation = self.generation.load(Ordering::Acquire);
+        let Ok(mut ring) = self.inner.lock() else {
+            out.clear();
+            return;
+        };
+        ring.sync_generation(generation);
+
+        let len = ring.filled;
+        out.len = len;
+        if len == 0 {
+            out.stereo = false;
+            return;
+        }
+
+        let start = (ring.pos + CAPACITY - len) & MASK;
+        read_wrapping(&ring.left, start, &mut out.left[..len]);
+        read_wrapping(&ring.right, start, &mut out.right[..len]);
+        drop(ring);
+
+        // 单声道音源的左右样本由 PcmTap 逐位复制而来，故精确比较即可，无需 epsilon。
+        out.stereo = out.left[..len] != out.right[..len];
+    }
+}
+
+impl Default for PcmRing {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// 把 `src` 写进环形数组 `dst` 的 `pos` 处，跨越末端时回绕。要求 `src.len() <= dst.len()`。
+fn write_wrapping(dst: &mut [f32], pos: usize, src: &[f32]) {
+    let head = (dst.len() - pos).min(src.len());
+    dst[pos..pos + head].copy_from_slice(&src[..head]);
+    dst[..src.len() - head].copy_from_slice(&src[head..]);
+}
+
+/// 从环形数组 `src` 的 `pos` 处连续读满 `dst`，跨越末端时回绕。
+fn read_wrapping(src: &[f32], pos: usize, dst: &mut [f32]) {
+    let head = (src.len() - pos).min(dst.len());
+    dst[..head].copy_from_slice(&src[pos..pos + head]);
+    let tail = dst.len() - head;
+    dst[head..].copy_from_slice(&src[..tail]);
+}
+
+/// 抽头的写入端：每样本调用 [`PcmTap::push_sample`]，攒满一批自动落环。
+///
+/// 暂存数组私有且无任何同步，因此每样本的开销只是一次数组写入 —— 相对
+/// `EqSource` 本身每样本 10 次原子读加 10 级 biquad，属噪声级。
+#[derive(Debug)]
+pub struct PcmTap {
+    ring: std::sync::Arc<PcmRing>,
+    left: Box<[f32]>,
+    right: Box<[f32]>,
+    len: usize,
+    channels: usize,
+    sample_rate: u32,
+}
+
+impl PcmTap {
+    pub fn new(ring: std::sync::Arc<PcmRing>, channels: usize, sample_rate: u32) -> Self {
+        Self {
+            ring,
+            left: vec![0.0; FLUSH_FRAMES].into_boxed_slice(),
+            right: vec![0.0; FLUSH_FRAMES].into_boxed_slice(),
+            len: 0,
+            channels: channels.max(1),
+            sample_rate,
+        }
+    }
+
+    /// 送入一个样本，`channel` 为其在当前帧内的声道序号。
+    pub fn push_sample(&mut self, channel: usize, sample: f32) {
+        match channel {
+            0 => self.left[self.len] = sample,
+            1 => self.right[self.len] = sample,
+            // 多声道音源只取前两路：示波器画的是立体声像，其余声道无处安放。
+            _ => {}
+        }
+
+        if channel + 1 < self.channels {
+            return;
+        }
+        if self.channels == 1 {
+            self.right[self.len] = self.left[self.len];
+        }
+
+        self.len += 1;
+        if self.len == self.left.len() {
+            self.flush();
+        }
+    }
+
+    /// 跳转后调用：暂存与环内的样本都属于跳转前的位置。
+    pub fn reset(&mut self) {
+        self.len = 0;
+        self.ring.reset();
+    }
+
+    fn flush(&mut self) {
+        if self.len == 0 {
+            return;
+        }
+        self.ring.push(
+            &self.left[..self.len],
+            &self.right[..self.len],
+            self.sample_rate,
+        );
+        self.len = 0;
+    }
+}

--- a/src/tmplayer/data/config.rs
+++ b/src/tmplayer/data/config.rs
@@ -144,6 +144,17 @@ pub enum VisualizeMode {
 }
 
 impl VisualizeMode {
+    /// 该模式是否依赖 cava 的频谱数据。示波器读播放链路上的 PCM 抽头，不需要。
+    pub fn needs_cava(self) -> bool {
+        matches!(self, VisualizeMode::Bars)
+    }
+
+    /// 数据源就绪，可供用户选中。
+    pub fn is_available(self) -> bool {
+        !self.needs_cava() || crate::tmplayer::audio::cava::is_available()
+    }
+
+    /// 切到下一个**可用**模式：数据源缺失的模式被跳过，而不是让整项无法调整。
     pub fn cycle(self, delta: i32) -> Self {
         const MODES: [VisualizeMode; 3] = [
             VisualizeMode::Off,
@@ -151,9 +162,13 @@ impl VisualizeMode {
             VisualizeMode::Oscilloscope,
         ];
 
-        let index = MODES.iter().position(|mode| *mode == self).unwrap_or(1) as i32;
-        let next = (index + delta).rem_euclid(MODES.len() as i32) as usize;
-        MODES[next]
+        let len = MODES.len() as i32;
+        let step = if delta < 0 { -1 } else { 1 };
+        let start = MODES.iter().position(|mode| *mode == self).unwrap_or(1) as i32;
+        (1..=len)
+            .map(|offset| MODES[(start + step * offset).rem_euclid(len) as usize])
+            .find(|mode| mode.is_available())
+            .unwrap_or(self)
     }
 }
 
@@ -250,7 +265,8 @@ fn default_visualize() -> VisualizeMode {
     if crate::tmplayer::audio::cava::is_available() {
         VisualizeMode::Bars
     } else {
-        VisualizeMode::Off
+        // 示波器不依赖 cava，比直接关掉可视化更有用。
+        VisualizeMode::Oscilloscope
     }
 }
 
@@ -431,10 +447,11 @@ impl Config {
             cfg.spectrum_hz = 60;
         }
 
-        let mut forced_visualize_off = false;
-        if !crate::tmplayer::audio::cava::is_available() && cfg.visualize != VisualizeMode::Off {
-            cfg.visualize = VisualizeMode::Off;
-            forced_visualize_off = true;
+        let mut forced_visualize_fallback = false;
+        if !cfg.visualize.is_available() {
+            // 只有依赖 cava 的模式会落到这里；退到同样无需外部进程的示波器。
+            cfg.visualize = VisualizeMode::Oscilloscope;
+            forced_visualize_fallback = true;
         }
 
         let mut migrated_legacy_sidebar = false;
@@ -473,7 +490,7 @@ impl Config {
             || !raw.contains("keybind_toggle_like_fullscreen")
             || legacy_startup_folder_key_present
             || !raw.contains("spectrum_hz")
-            || forced_visualize_off
+            || forced_visualize_fallback
             || migrated_legacy_sidebar
         {
             let _ = cfg.save();

--- a/src/tmplayer/mod.rs
+++ b/src/tmplayer/mod.rs
@@ -11,6 +11,7 @@ use anyhow::Result;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
 use crate::data::config::{
@@ -119,6 +120,8 @@ pub trait HostPlaybackBridge {
     async fn tick(&mut self);
     fn metadata_signature(&self) -> u64;
     fn runtime_snapshot(&self) -> HostPlaybackRuntimeSnapshot;
+    /// 宿主播放链路上的 PCM 抽头环，示波器由此取真实波形。
+    fn pcm_ring(&self) -> Arc<crate::tmplayer::audio::pcm_tap::PcmRing>;
     fn snapshot(&mut self) -> HostPlaybackSnapshot;
     fn config_snapshot(&self) -> HostConfigSync;
     async fn apply_config_sync(&mut self, config: HostConfigSync);

--- a/src/tmplayer/render/oscilloscope_renderer.rs
+++ b/src/tmplayer/render/oscilloscope_renderer.rs
@@ -33,21 +33,13 @@ const TRIGGER_HYSTERESIS: f32 = 0.05;
 /// 滞回带的绝对下限：静音时不让浮点噪声触发。
 const TRIGGER_FLOOR: f32 = 1.0e-4;
 
-/// 右声道颜色向背景压暗的比例。
-///
-/// 不能靠色相区分左右：System 主题的 accent / accent2 / accent3 全是 `#FFFFFF`，
-/// 任何色相方案在该主题下都不可见。压暗在所有主题下都成立。
-const RIGHT_CHANNEL_DIM: f32 = 0.55;
-
 /// 示波器的复用缓冲。存在 `AppState` 里，渲染路径因此不做任何分配。
 #[derive(Debug, Default)]
 pub struct ScopeScratch {
     snapshot: PcmSnapshot,
-    /// 每单元格一个盲文点位掩码，行优先
-    left: Vec<u8>,
-    right: Vec<u8>,
-    /// 本帧右声道是否真的画了东西
-    stereo: bool,
+    /// 每单元格一个盲文点位掩码，行优先。左右声道叠加在同一张图上：
+    /// 一个盲文单元格只有一个前景色，配色按行取纵向渐变，与声道无关。
+    grid: Vec<u8>,
 }
 
 pub fn render(f: &mut Frame, area: Rect, app: &mut AppState) {
@@ -67,19 +59,10 @@ pub fn render(f: &mut Frame, area: Rect, app: &mut AppState) {
 }
 
 fn rasterize(scope: &mut ScopeScratch, w_cells: usize, h_cells: usize) {
-    let ScopeScratch {
-        snapshot,
-        left,
-        right,
-        stereo,
-    } = scope;
+    let ScopeScratch { snapshot, grid } = scope;
 
-    let cells = w_cells * h_cells;
-    left.clear();
-    left.resize(cells, 0);
-    right.clear();
-    right.resize(cells, 0);
-    *stereo = false;
+    grid.clear();
+    grid.resize(w_cells * h_cells, 0);
 
     let window = window_frames(snapshot);
     if window < 2 {
@@ -88,19 +71,19 @@ fn rasterize(scope: &mut ScopeScratch, w_cells: usize, h_cells: usize) {
     let start = trigger_offset(snapshot, window);
 
     draw_channel(
-        left,
+        grid,
         w_cells,
         h_cells,
         &snapshot.left[start..start + window],
     );
+    // 单声道音源两声道逐位相同，再画一遍只是白烧一半光栅化开销。
     if snapshot.stereo {
         draw_channel(
-            right,
+            grid,
             w_cells,
             h_cells,
             &snapshot.right[start..start + window],
         );
-        *stereo = true;
     }
 }
 
@@ -188,18 +171,17 @@ fn sample_row(v: f32, h_px: i32) -> i32 {
     ((1.0 - v) * 0.5 * span).round().clamp(0.0, span) as i32
 }
 
-/// 逐单元格直写帧缓冲：颜色按格变化（左声道 / 右声道 / 中线三种），
-/// 整行一个 Span 表达不了，直写也省掉每帧的字符串分配。
+/// 逐单元格直写帧缓冲。波形配色沿用原有逻辑：整行一个颜色，按行在
+/// `accent2` → `accent3` 之间做纵向渐变。直写只是省掉每帧的字符串分配。
 fn paint(f: &mut Frame, area: Rect, app: &AppState, w_cells: usize, h_cells: usize) {
-    let scope = &app.scope;
-    let h_px = (h_cells * 4) as i32;
+    let grid = &app.scope.grid;
 
-    // 中线 graticule：用盲文点位精确落在零电平那一子行上，而非单元格的几何中心。
-    let zero_row = sample_row(0.0, h_px) as usize;
-    let (graticule_row, graticule_sub) = (zero_row / 4, zero_row % 4);
-    let graticule =
-        braille_from_bits(braille_bit(0, graticule_sub) | braille_bit(1, graticule_sub));
-    let graticule_fg = app.theme.color_subtext();
+    // 零电平中轴线。用盲文点位对准真正的零，而非单元格的几何中心；只画在
+    // 没有波形的格子里——一格只有一个前景色，波形优先。
+    let zero = sample_row(0.0, (h_cells * 4) as i32) as usize;
+    let (axis_row, axis_sub) = (zero / 4, zero % 4);
+    let axis_glyph = braille_from_bits(braille_bit(0, axis_sub) | braille_bit(1, axis_sub));
+    let axis_fg = app.theme.color_surface();
 
     let buf = f.buffer_mut();
     let clip = area.intersection(buf.area);
@@ -210,25 +192,21 @@ fn paint(f: &mut Frame, area: Rect, app: &AppState, w_cells: usize, h_cells: usi
         } else {
             row as f32 / (h_cells - 1) as f32
         };
-        let trace_fg = vertical_gradient_color(app, t);
-        let right_fg = mix(trace_fg, app.theme.color_base(), RIGHT_CHANNEL_DIM);
+        let fg = vertical_gradient_color(app, t);
 
         for col in 0..clip.width as usize {
-            let index = row * w_cells + col;
-            let left = scope.left[index];
-            let right = if scope.stereo { scope.right[index] } else { 0 };
-
-            // 两声道重叠的格子归左声道：亮色压暗色，与叠加显示的惯例一致。
-            let (glyph, fg) = match (left, right) {
-                (0, 0) if row == graticule_row => (graticule, graticule_fg),
-                (0, 0) => continue,
-                (0, r) => (braille_from_bits(r), right_fg),
-                (l, r) => (braille_from_bits(l | r), trace_fg),
+            let bits = grid[row * w_cells + col];
+            let (glyph, colour) = if bits != 0 {
+                (braille_from_bits(bits), fg)
+            } else if row == axis_row {
+                (axis_glyph, axis_fg)
+            } else {
+                continue;
             };
 
             if let Some(cell) = buf.cell_mut((clip.x + col as u16, clip.y + row as u16)) {
                 cell.set_char(glyph);
-                cell.set_fg(fg);
+                cell.set_fg(colour);
             }
         }
     }

--- a/src/tmplayer/render/oscilloscope_renderer.rs
+++ b/src/tmplayer/render/oscilloscope_renderer.rs
@@ -14,7 +14,9 @@
 
 use crate::tmplayer::app::state::AppState;
 use crate::tmplayer::audio::pcm_tap::PcmSnapshot;
+use crate::tmplayer::ui::theme::Theme;
 use ratatui::Frame;
+use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::Color;
 
@@ -55,22 +57,33 @@ pub fn render(f: &mut Frame, area: Rect, app: &mut AppState) {
     }
 
     rasterize(&mut app.scope, w_cells, h_cells, app.scope_gain.value());
-    paint(f, area, app, w_cells, h_cells);
+    paint(
+        f.buffer_mut(),
+        area,
+        &app.scope.grid,
+        &app.theme,
+        w_cells,
+        h_cells,
+    );
 }
 
-/// `gain` 是幅度包络：播放中为 1，暂停后缓动到 0 把波形收回中线。归零后干脆
-/// 不画，让位给 `paint` 的中轴线——两者在零电平上是同一个字形，只是颜色不同。
+/// `gain` 是幅度包络：播放开始后张开到 1，停止后衰减回 0。
+///
+/// **归零不是不画**。`gain = 0` 时每个子列的 min/max 都映到零电平那一行，
+/// [`draw_channel`] 于是自然画出一条贯穿全宽的居中直线 —— 那条线就是波形本身，
+/// 不存在独立的中线元素。因为包络是全局的，所有子列同乘一个系数，落平必然
+/// 同时发生。
 fn rasterize(scope: &mut ScopeScratch, w_cells: usize, h_cells: usize, gain: f32) {
     let ScopeScratch { snapshot, grid } = scope;
 
     grid.clear();
     grid.resize(w_cells * h_cells, 0);
-    if gain <= 0.0 {
-        return;
-    }
 
     let window = window_frames(snapshot);
     if window < 2 {
+        // 环里还没有样本（无宿主、刚启动）。此时同样画居中直线，与落平后的
+        // 静止态是同一幅画面，不是空白。
+        draw_flat_line(grid, w_cells, h_cells);
         return;
     }
     let start = trigger_offset(snapshot, window);
@@ -91,6 +104,17 @@ fn rasterize(scope: &mut ScopeScratch, w_cells: usize, h_cells: usize, gain: f32
             &snapshot.right[start..start + window],
             gain,
         );
+    }
+}
+
+/// 无样本时的静止画面：零电平那一行铺满整宽。
+///
+/// 与 `gain = 0` 时 [`draw_channel`] 的输出逐点一致，两条路径因此收敛到同一幅
+/// 画面（`no_samples_matches_settled_frame` 守着这条等价）。
+fn draw_flat_line(grid: &mut [u8], w_cells: usize, h_cells: usize) {
+    let zero = sample_row(0.0, (h_cells * 4) as i32);
+    for col in 0..(w_cells * 2) as i32 {
+        set_pixel(grid, w_cells, h_cells, col, zero);
     }
 }
 
@@ -181,40 +205,28 @@ fn sample_row(v: f32, h_px: i32) -> i32 {
 
 /// 逐单元格直写帧缓冲。波形配色沿用原有逻辑：整行一个颜色，按行在
 /// `accent2` → `accent3` 之间做纵向渐变。直写只是省掉每帧的字符串分配。
-fn paint(f: &mut Frame, area: Rect, app: &AppState, w_cells: usize, h_cells: usize) {
-    let grid = &app.scope.grid;
-
-    // 零电平中轴线。用盲文点位对准真正的零，而非单元格的几何中心；只画在
-    // 没有波形的格子里——一格只有一个前景色，波形优先。
-    let zero = sample_row(0.0, (h_cells * 4) as i32) as usize;
-    let (axis_row, axis_sub) = (zero / 4, zero % 4);
-    let axis_glyph = braille_from_bits(braille_bit(0, axis_sub) | braille_bit(1, axis_sub));
-    let axis_fg = app.theme.color_surface();
-
-    let buf = f.buffer_mut();
+///
+/// 只画 grid 里有的东西：静止时那条居中直线是 `rasterize` 画出来的波形，
+/// 这里没有任何中线的特例分支。取 `Buffer` 而非 `Frame`，因此可离屏验证。
+fn paint(buf: &mut Buffer, area: Rect, grid: &[u8], theme: &Theme, w_cells: usize, h_cells: usize) {
     let clip = area.intersection(buf.area);
-
     for row in 0..clip.height as usize {
         let t = if h_cells <= 1 {
             1.0
         } else {
             row as f32 / (h_cells - 1) as f32
         };
-        let fg = vertical_gradient_color(app, t);
+        let fg = vertical_gradient_color(theme, t);
 
         for col in 0..clip.width as usize {
             let bits = grid[row * w_cells + col];
-            let (glyph, colour) = if bits != 0 {
-                (braille_from_bits(bits), fg)
-            } else if row == axis_row {
-                (axis_glyph, axis_fg)
-            } else {
+            if bits == 0 {
                 continue;
-            };
+            }
 
             if let Some(cell) = buf.cell_mut((clip.x + col as u16, clip.y + row as u16)) {
-                cell.set_char(glyph);
-                cell.set_fg(colour);
+                cell.set_char(braille_from_bits(bits));
+                cell.set_fg(fg);
             }
         }
     }
@@ -263,10 +275,8 @@ fn braille_from_bits(bits: u8) -> char {
     char::from_u32(0x2800 + bits as u32).unwrap_or(' ')
 }
 
-fn vertical_gradient_color(app: &AppState, t: f32) -> Color {
-    let top = app.theme.color_accent2();
-    let bottom = app.theme.color_accent3();
-    mix(top, bottom, t)
+fn vertical_gradient_color(theme: &Theme, t: f32) -> Color {
+    mix(theme.color_accent2(), theme.color_accent3(), t)
 }
 
 /// 非 truecolor 终端（`Ansi256` / `NoColor`）上主题色不是 `Color::Rgb`，
@@ -287,6 +297,7 @@ fn mix(a: Color, b: Color, t: f32) -> Color {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tmplayer::ui::theme::{ColorCapability, ThemeName, ThemePalette};
 
     const RATE: u32 = 48_000;
 
@@ -361,7 +372,7 @@ mod tests {
     }
 
     #[test]
-    fn quiet_signal_stays_near_the_centre_line() {
+    fn quiet_signal_stays_near_zero_level() {
         let (w_cells, h_cells) = (60usize, 8usize);
         let window = (RATE as f32 * WINDOW_MS / 1000.0) as usize;
         let mut snapshot = sine(440.0, 0.0, window * 4);
@@ -394,7 +405,7 @@ mod tests {
     }
 
     #[test]
-    fn gain_envelope_collapses_the_trace_toward_the_centre_line() {
+    fn gain_envelope_collapses_the_trace_toward_zero_level() {
         let (w_cells, h_cells) = (60usize, 8usize);
         let window = (RATE as f32 * WINDOW_MS / 1000.0) as usize;
         let snapshot = sine(440.0, 0.0, window * 4);
@@ -408,12 +419,152 @@ mod tests {
             rows.last().map(|hi| hi - rows[0] + 1).unwrap_or(0)
         };
 
-        // 幅度包络越小，波形占的行数越少 —— 暂停后就是这样收回中线的。
+        // 幅度包络越小，波形占的行数越少 —— 暂停后就是这样落回零电平的。
         let full = span(1.0);
         let half = span(0.5);
-        let settled = span(0.0);
         assert_eq!(full, h_cells, "满幅应撑满面板");
-        assert!(half < full && half > settled, "half={half} full={full}");
-        assert_eq!(settled, 1, "归零后只剩中线那一行");
+        assert!(half < full, "half={half} full={full}");
+        assert_eq!(span(0.0), 1, "只剩零电平那一行");
+    }
+
+    /// 落平后波形退化成居中直线：由 `draw_channel` 自己画出来，不是外加的中线。
+    #[test]
+    fn settled_scope_rasterizes_a_centred_flat_line() {
+        let (w_cells, h_cells) = (60usize, 8usize);
+        let mut scope = ScopeScratch {
+            snapshot: sine(440.0, 0.0, 8192),
+            grid: Vec::new(),
+        };
+
+        rasterize(&mut scope, w_cells, h_cells, 0.0);
+
+        // 恰好一行被点亮，且落在零电平所在的那一行。
+        let lit: Vec<usize> = (0..h_cells)
+            .filter(|row| (0..w_cells).any(|col| scope.grid[row * w_cells + col] != 0))
+            .collect();
+        let zero_row = sample_row(0.0, (h_cells * 4) as i32) as usize / 4;
+        assert_eq!(lit, vec![zero_row], "应只点亮零电平那一行");
+
+        // 且贯穿全宽：每一格都有点，才是一条不断的直线。
+        assert!(
+            (0..w_cells).all(|col| scope.grid[zero_row * w_cells + col] != 0),
+            "直线有断点"
+        );
+    }
+
+    /// 环里没有样本时（无宿主、刚启动）画的必须与落平后完全一致 —— 否则启动
+    /// 瞬间会闪一下空白，或停止后画面与启动态不符。
+    #[test]
+    fn no_samples_matches_settled_frame() {
+        let (w_cells, h_cells) = (60usize, 8usize);
+
+        let mut empty = ScopeScratch::default();
+        rasterize(&mut empty, w_cells, h_cells, 1.0);
+
+        let mut settled = ScopeScratch {
+            snapshot: sine(440.0, 0.0, 8192),
+            grid: Vec::new(),
+        };
+        rasterize(&mut settled, w_cells, h_cells, 0.0);
+
+        assert_eq!(empty.grid, settled.grid);
+    }
+
+    fn test_theme() -> Theme {
+        Theme {
+            name: ThemeName::Frappe,
+            palette: ThemePalette {
+                text: (198, 208, 245),
+                subtext: (165, 173, 206),
+                base: (48, 52, 70),
+                surface: (65, 69, 89),
+                buff: (81, 87, 109),
+                accent: (140, 170, 238),
+                accent2: (133, 193, 220),
+                accent3: (202, 158, 230),
+            },
+            capability: ColorCapability::TrueColor,
+        }
+    }
+
+    /// 离屏渲染一帧，返回 (点亮的单元格数, 出现过的前景色集合)。
+    fn paint_frame(gain: f32) -> (usize, Vec<Color>) {
+        let (w_cells, h_cells) = (60u16, 8u16);
+        let area = Rect::new(0, 0, w_cells, h_cells);
+        let mut scope = ScopeScratch {
+            snapshot: sine(440.0, 0.0, 8192),
+            grid: Vec::new(),
+        };
+        rasterize(&mut scope, w_cells as usize, h_cells as usize, gain);
+
+        let mut buf = Buffer::empty(area);
+        paint(
+            &mut buf,
+            area,
+            &scope.grid,
+            &test_theme(),
+            w_cells as usize,
+            h_cells as usize,
+        );
+
+        let mut colours = Vec::new();
+        let mut lit = 0;
+        for y in 0..h_cells {
+            for x in 0..w_cells {
+                let cell = &buf[(x, y)];
+                if cell.symbol() == " " {
+                    continue;
+                }
+                lit += 1;
+                if !colours.contains(&cell.fg) {
+                    colours.push(cell.fg);
+                }
+            }
+        }
+        (lit, colours)
+    }
+
+    #[test]
+    fn settled_frame_is_a_single_centred_waveform_row() {
+        let (w_cells, _) = (60usize, 8usize);
+        let (playing, _) = paint_frame(1.0);
+        let (settled, colours) = paint_frame(0.0);
+
+        assert!(playing > w_cells, "播放中应画出波形");
+        // 静止态正好一整行：波形自己收成的直线，不多不少。
+        assert_eq!(settled, w_cells, "静止态应只剩居中那一行");
+        // 且用波形的渐变色，不是任何专供中线的颜色 —— 没有独立的中线元素。
+        assert_eq!(colours.len(), 1, "一行只有一个颜色: {colours:?}");
+        assert_ne!(colours[0], test_theme().color_surface());
+    }
+
+    /// 静止那条线必须落在垂直居中位置。
+    #[test]
+    fn settled_line_sits_vertically_centred() {
+        for h_cells in [4usize, 6, 8, 12] {
+            let w_cells = 8usize;
+            let area = Rect::new(0, 0, w_cells as u16, h_cells as u16);
+            let mut scope = ScopeScratch::default();
+            rasterize(&mut scope, w_cells, h_cells, 0.0);
+
+            let mut buf = Buffer::empty(area);
+            paint(&mut buf, area, &scope.grid, &test_theme(), w_cells, h_cells);
+
+            // 收集点亮的子行，取其中点，与面板正中比较。
+            let mut subrows = Vec::new();
+            for row in 0..h_cells {
+                let bits = scope.grid[row * w_cells];
+                for dy in 0..4 {
+                    if bits & braille_bit(0, dy) != 0 {
+                        subrows.push(row * 4 + dy);
+                    }
+                }
+            }
+            assert_eq!(subrows.len(), 1, "h={h_cells} 应只有一条线");
+
+            let centre = (h_cells * 4 - 1) as f32 / 2.0;
+            let offset = (subrows[0] as f32 - centre).abs();
+            assert!(offset <= 0.5, "h={h_cells} 偏离中心 {offset} 子行");
+        }
     }
 }

--- a/src/tmplayer/render/oscilloscope_renderer.rs
+++ b/src/tmplayer/render/oscilloscope_renderer.rs
@@ -297,3 +297,112 @@ fn mix(a: Color, b: Color, t: f32) -> Color {
         _ => a,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const RATE: u32 = 48_000;
+
+    fn sine(freq: f32, phase: f32, len: usize) -> PcmSnapshot {
+        let mut snapshot = PcmSnapshot::default();
+        for i in 0..len {
+            let t = i as f32 / RATE as f32;
+            snapshot.left[i] = (std::f32::consts::TAU * freq * t + phase).sin();
+            snapshot.right[i] = snapshot.left[i];
+        }
+        snapshot.len = len;
+        snapshot.sample_rate = RATE;
+        snapshot
+    }
+
+    #[test]
+    fn trigger_locks_onto_a_rising_zero_crossing_at_any_phase() {
+        let window = (RATE as f32 * WINDOW_MS / 1000.0) as usize;
+        for step in 0..8 {
+            let phase = step as f32 * std::f32::consts::TAU / 8.0;
+            let snapshot = sine(440.0, phase, window * 4);
+            let start = trigger_offset(&snapshot, window);
+
+            // 触发点必须真的落在上升沿上：本身刚过零、前一个为负、后一个为正。
+            assert!(snapshot.left[start] >= 0.0 && snapshot.left[start] < 0.07);
+            assert!(snapshot.left[start - 1] < 0.0);
+            assert!(snapshot.left[start + 1] > 0.0);
+        }
+    }
+
+    #[test]
+    fn silence_falls_back_to_the_newest_window() {
+        let snapshot = PcmSnapshot {
+            len: 4096,
+            sample_rate: RATE,
+            ..Default::default()
+        };
+
+        let window = window_frames(&snapshot);
+        assert_eq!(trigger_offset(&snapshot, window), snapshot.len - window);
+    }
+
+    #[test]
+    fn full_scale_trace_is_continuous_and_spans_the_grid() {
+        let (w_cells, h_cells) = (60usize, 8usize);
+        let window = (RATE as f32 * WINDOW_MS / 1000.0) as usize;
+        let snapshot = sine(440.0, 0.0, window * 4);
+        let start = trigger_offset(&snapshot, window);
+
+        let mut grid = vec![0u8; w_cells * h_cells];
+        draw_channel(
+            &mut grid,
+            w_cells,
+            h_cells,
+            &snapshot.left[start..start + window],
+        );
+
+        // 每一列都得有点亮的格子：包络带连续，接合逻辑没漏掉断点。
+        for col in 0..w_cells {
+            assert!(
+                (0..h_cells).any(|row| grid[row * w_cells + col] != 0),
+                "column {col} is empty"
+            );
+        }
+        // 绝对映射：满幅信号必须触到顶行与底行，不被归一化压扁。
+        assert!((0..w_cells).any(|col| grid[col] != 0), "top row untouched");
+        assert!(
+            (0..w_cells).any(|col| grid[(h_cells - 1) * w_cells + col] != 0),
+            "bottom row untouched"
+        );
+    }
+
+    #[test]
+    fn quiet_signal_stays_near_the_centre_line() {
+        let (w_cells, h_cells) = (60usize, 8usize);
+        let window = (RATE as f32 * WINDOW_MS / 1000.0) as usize;
+        let mut snapshot = sine(440.0, 0.0, window * 4);
+        for v in snapshot.left.iter_mut() {
+            *v *= 0.02;
+        }
+
+        let mut grid = vec![0u8; w_cells * h_cells];
+        draw_channel(&mut grid, w_cells, h_cells, &snapshot.left[0..window]);
+
+        // 顶行与底行必须是空的：响度动态没有被 AGC 抹掉。
+        assert!((0..w_cells).all(|col| grid[col] == 0));
+        assert!((0..w_cells).all(|col| grid[(h_cells - 1) * w_cells + col] == 0));
+    }
+
+    #[test]
+    fn fewer_samples_than_subcolumns_still_draws_every_column() {
+        let (w_cells, h_cells) = (60usize, 6usize);
+        let samples: Vec<f32> = (0..17).map(|i| ((i % 5) as f32 - 2.0) / 2.0).collect();
+
+        let mut grid = vec![0u8; w_cells * h_cells];
+        draw_channel(&mut grid, w_cells, h_cells, &samples);
+
+        for col in 0..w_cells {
+            assert!(
+                (0..h_cells).any(|row| grid[row * w_cells + col] != 0),
+                "column {col} is empty"
+            );
+        }
+    }
+}

--- a/src/tmplayer/render/oscilloscope_renderer.rs
+++ b/src/tmplayer/render/oscilloscope_renderer.rs
@@ -54,15 +54,20 @@ pub fn render(f: &mut Frame, area: Rect, app: &mut AppState) {
         None => app.scope.snapshot.clear(),
     }
 
-    rasterize(&mut app.scope, w_cells, h_cells);
+    rasterize(&mut app.scope, w_cells, h_cells, app.scope_gain.value());
     paint(f, area, app, w_cells, h_cells);
 }
 
-fn rasterize(scope: &mut ScopeScratch, w_cells: usize, h_cells: usize) {
+/// `gain` 是幅度包络：播放中为 1，暂停后缓动到 0 把波形收回中线。归零后干脆
+/// 不画，让位给 `paint` 的中轴线——两者在零电平上是同一个字形，只是颜色不同。
+fn rasterize(scope: &mut ScopeScratch, w_cells: usize, h_cells: usize, gain: f32) {
     let ScopeScratch { snapshot, grid } = scope;
 
     grid.clear();
     grid.resize(w_cells * h_cells, 0);
+    if gain <= 0.0 {
+        return;
+    }
 
     let window = window_frames(snapshot);
     if window < 2 {
@@ -75,6 +80,7 @@ fn rasterize(scope: &mut ScopeScratch, w_cells: usize, h_cells: usize) {
         w_cells,
         h_cells,
         &snapshot.left[start..start + window],
+        gain,
     );
     // 单声道音源两声道逐位相同，再画一遍只是白烧一半光栅化开销。
     if snapshot.stereo {
@@ -83,6 +89,7 @@ fn rasterize(scope: &mut ScopeScratch, w_cells: usize, h_cells: usize) {
             w_cells,
             h_cells,
             &snapshot.right[start..start + window],
+            gain,
         );
     }
 }
@@ -136,7 +143,7 @@ fn mono(snapshot: &PcmSnapshot, index: usize) -> f32 {
 /// 相邻子列的跨度不相接时互相延伸一格，轨迹因此连续 —— 陡沿处等价于连线，
 /// 但不必单独走一遍 Bresenham。样本比子列还少时每列复用最近的样本，
 /// 由同一段接合逻辑连成折线，无需第二条代码路径。
-fn draw_channel(grid: &mut [u8], w_cells: usize, h_cells: usize, samples: &[f32]) {
+fn draw_channel(grid: &mut [u8], w_cells: usize, h_cells: usize, samples: &[f32], gain: f32) {
     let w_px = w_cells * 2;
     let h_px = (h_cells * 4) as i32;
     let n = samples.len();
@@ -151,7 +158,8 @@ fn draw_channel(grid: &mut [u8], w_cells: usize, h_cells: usize, samples: &[f32]
             hi = hi.max(v);
         }
 
-        let (top, bottom) = (sample_row(hi, h_px), sample_row(lo, h_px));
+        // gain 非负，先取极值再缩放与逐样本缩放等价，但少 n-2 次乘法。
+        let (top, bottom) = (sample_row(hi * gain, h_px), sample_row(lo * gain, h_px));
         let (mut from, mut to) = (top, bottom);
         if let Some((prev_top, prev_bottom)) = prev {
             from = from.min(prev_bottom);
@@ -334,6 +342,7 @@ mod tests {
             w_cells,
             h_cells,
             &snapshot.left[start..start + window],
+            1.0,
         );
 
         // 每一列都得有点亮的格子：包络带连续，接合逻辑没漏掉断点。
@@ -361,7 +370,7 @@ mod tests {
         }
 
         let mut grid = vec![0u8; w_cells * h_cells];
-        draw_channel(&mut grid, w_cells, h_cells, &snapshot.left[0..window]);
+        draw_channel(&mut grid, w_cells, h_cells, &snapshot.left[0..window], 1.0);
 
         // 顶行与底行必须是空的：响度动态没有被 AGC 抹掉。
         assert!((0..w_cells).all(|col| grid[col] == 0));
@@ -374,7 +383,7 @@ mod tests {
         let samples: Vec<f32> = (0..17).map(|i| ((i % 5) as f32 - 2.0) / 2.0).collect();
 
         let mut grid = vec![0u8; w_cells * h_cells];
-        draw_channel(&mut grid, w_cells, h_cells, &samples);
+        draw_channel(&mut grid, w_cells, h_cells, &samples, 1.0);
 
         for col in 0..w_cells {
             assert!(
@@ -382,5 +391,29 @@ mod tests {
                 "column {col} is empty"
             );
         }
+    }
+
+    #[test]
+    fn gain_envelope_collapses_the_trace_toward_the_centre_line() {
+        let (w_cells, h_cells) = (60usize, 8usize);
+        let window = (RATE as f32 * WINDOW_MS / 1000.0) as usize;
+        let snapshot = sine(440.0, 0.0, window * 4);
+
+        let span = |gain: f32| {
+            let mut grid = vec![0u8; w_cells * h_cells];
+            draw_channel(&mut grid, w_cells, h_cells, &snapshot.left[0..window], gain);
+            let rows: Vec<usize> = (0..h_cells)
+                .filter(|row| (0..w_cells).any(|col| grid[row * w_cells + col] != 0))
+                .collect();
+            rows.last().map(|hi| hi - rows[0] + 1).unwrap_or(0)
+        };
+
+        // 幅度包络越小，波形占的行数越少 —— 暂停后就是这样收回中线的。
+        let full = span(1.0);
+        let half = span(0.5);
+        let settled = span(0.0);
+        assert_eq!(full, h_cells, "满幅应撑满面板");
+        assert!(half < full && half > settled, "half={half} full={full}");
+        assert_eq!(settled, 1, "归零后只剩中线那一行");
     }
 }

--- a/src/tmplayer/render/oscilloscope_renderer.rs
+++ b/src/tmplayer/render/oscilloscope_renderer.rs
@@ -1,207 +1,235 @@
+//! 真 PCM 时域示波器。
+//!
+//! 样本来自 `audio::pcm_tap` 的共享环（宿主播放链路上的抽头），不经 cava。
+//! 三个要素照搬硬件示波器，缺一则观感立刻退化：
+//!
+//! 1. **上升沿触发**：每帧在最新一段样本里找一个带滞回的零交叉作为窗口起点，
+//!    周期信号因此在屏上静止。没有它，窗口只能随时间平移，每帧移动
+//!    `(1/帧率)/窗口时长` 个屏宽，远超人眼可跟踪的范围，画面就是一片沸腾的噪点。
+//! 2. **峰值（min/max）抽取**：每个子列画该段样本的极值包络带，而不是采一个点。
+//!    包络对时域欠采样免疫，高频段因此是稳定的实心带而非混叠锯齿 ——
+//!    这正是示波器的 peak-detect 采集模式。
+//! 3. **绝对幅度映射**：不归一化、不做 AGC。安静段贴中线、高潮段撑满，
+//!    响度动态如实呈现。
+
 use crate::tmplayer::app::state::AppState;
+use crate::tmplayer::audio::pcm_tap::PcmSnapshot;
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::{Color, Style};
-use ratatui::text::{Line, Span};
-use ratatui::widgets::Paragraph;
+use ratatui::style::Color;
 
-const BINS: usize = 64;
-const F_MIN_HZ: f32 = 40.0;
-const F_MAX_HZ: f32 = 8000.0;
-const GAMMA: f32 = 1.7;
-const DISPLAY_WINDOW_SEC: f32 = 0.030;
-const GAIN: f32 = 0.90;
+/// 显示窗口时长，相当于示波器的 time/div。
+///
+/// 40 ms 在 40 Hz 处约一个周期、在 1 kHz 处约 40 个周期：低频看得出波形，
+/// 高频在峰值抽取下收敛成稳定包络。
+const WINDOW_MS: f32 = 40.0;
 
-pub fn render(f: &mut Frame, area: Rect, app: &AppState) {
-    let w_cells = area.width as usize;
-    let h_cells = area.height as usize;
+/// 触发搜索区间，须覆盖最低可见频率的一个周期（40 Hz → 25 ms）。
+const TRIGGER_SEARCH_MS: f32 = 25.0;
+
+/// 触发滞回带，相对搜索区间内的峰值。抑制噪声在零点附近反复误触发。
+const TRIGGER_HYSTERESIS: f32 = 0.05;
+
+/// 滞回带的绝对下限：静音时不让浮点噪声触发。
+const TRIGGER_FLOOR: f32 = 1.0e-4;
+
+/// 右声道颜色向背景压暗的比例。
+///
+/// 不能靠色相区分左右：System 主题的 accent / accent2 / accent3 全是 `#FFFFFF`，
+/// 任何色相方案在该主题下都不可见。压暗在所有主题下都成立。
+const RIGHT_CHANNEL_DIM: f32 = 0.55;
+
+/// 示波器的复用缓冲。存在 `AppState` 里，渲染路径因此不做任何分配。
+#[derive(Debug, Default)]
+pub struct ScopeScratch {
+    snapshot: PcmSnapshot,
+    /// 每单元格一个盲文点位掩码，行优先
+    left: Vec<u8>,
+    right: Vec<u8>,
+    /// 本帧右声道是否真的画了东西
+    stereo: bool,
+}
+
+pub fn render(f: &mut Frame, area: Rect, app: &mut AppState) {
+    let (w_cells, h_cells) = (area.width as usize, area.height as usize);
     if w_cells == 0 || h_cells == 0 {
         return;
     }
 
-    // Braille resolution: 2x4 pixels per terminal cell.
-    let w_px = w_cells * 2;
-    let h_px = h_cells * 4;
-    if w_px == 0 || h_px == 0 {
-        return;
+    // 环由宿主持有：先克隆 Arc 再借 scratch，避免同时借用 app 的两个字段。
+    match app.pcm_ring.clone() {
+        Some(ring) => ring.snapshot(&mut app.scope.snapshot),
+        None => app.scope.snapshot.clear(),
     }
 
-    let mid_y = ((h_px as i32) - 1) / 2;
-    let (y_left, y_right) = synthesize_waveforms(app, w_px, mid_y);
+    rasterize(&mut app.scope, w_cells, h_cells);
+    paint(f, area, app, w_cells, h_cells);
+}
 
-    let cell_bits = rasterize_braille(w_cells, h_cells, &y_left, &y_right);
+fn rasterize(scope: &mut ScopeScratch, w_cells: usize, h_cells: usize) {
+    let ScopeScratch {
+        snapshot,
+        left,
+        right,
+        stereo,
+    } = scope;
 
-    // Render per-line vertical gradient using theme colors.
-    let mut lines: Vec<Line> = Vec::with_capacity(h_cells);
-    for row in 0..h_cells {
+    let cells = w_cells * h_cells;
+    left.clear();
+    left.resize(cells, 0);
+    right.clear();
+    right.resize(cells, 0);
+    *stereo = false;
+
+    let window = window_frames(snapshot);
+    if window < 2 {
+        return;
+    }
+    let start = trigger_offset(snapshot, window);
+
+    draw_channel(
+        left,
+        w_cells,
+        h_cells,
+        &snapshot.left[start..start + window],
+    );
+    if snapshot.stereo {
+        draw_channel(
+            right,
+            w_cells,
+            h_cells,
+            &snapshot.right[start..start + window],
+        );
+        *stereo = true;
+    }
+}
+
+/// 显示窗口帧数：按固定时长换算，与终端宽度无关 —— 宽度只影响抽取密度。
+fn window_frames(snapshot: &PcmSnapshot) -> usize {
+    if snapshot.sample_rate == 0 {
+        return 0;
+    }
+    let by_time = (snapshot.sample_rate as f32 * WINDOW_MS / 1000.0) as usize;
+    by_time.min(snapshot.len)
+}
+
+/// 找窗口起点：在最新一窗之前的搜索区间内取**最后**一个带滞回的上升沿零交叉，
+/// 使画面既相位稳定又尽量新。
+///
+/// 触发信号取左右声道之和：任一声道静音时仍能锁定，且不破坏声道间相位差。
+/// 找不到（静音、纯直流）就回落到最新一窗，即示波器的自由运行模式。
+fn trigger_offset(snapshot: &PcmSnapshot, window: usize) -> usize {
+    let latest = snapshot.len - window;
+    let search = ((snapshot.sample_rate as f32 * TRIGGER_SEARCH_MS / 1000.0) as usize).min(latest);
+    let begin = latest - search;
+
+    let mut peak = 0.0f32;
+    for i in begin..latest {
+        peak = peak.max(mono(snapshot, i).abs());
+    }
+    let hysteresis = (peak * TRIGGER_HYSTERESIS).max(TRIGGER_FLOOR);
+
+    // 必须先跌破 -hysteresis 才算“上膛”，再向上穿过零点才触发。
+    let mut armed = false;
+    let mut found = None;
+    for i in begin..latest {
+        let v = mono(snapshot, i);
+        if v <= -hysteresis {
+            armed = true;
+        } else if armed && v >= 0.0 {
+            armed = false;
+            found = Some(i);
+        }
+    }
+    found.unwrap_or(latest)
+}
+
+fn mono(snapshot: &PcmSnapshot, index: usize) -> f32 {
+    (snapshot.left[index] + snapshot.right[index]) * 0.5
+}
+
+/// 峰值抽取：每个子列取该段样本的 min/max 并填满其间像素。
+///
+/// 相邻子列的跨度不相接时互相延伸一格，轨迹因此连续 —— 陡沿处等价于连线，
+/// 但不必单独走一遍 Bresenham。样本比子列还少时每列复用最近的样本，
+/// 由同一段接合逻辑连成折线，无需第二条代码路径。
+fn draw_channel(grid: &mut [u8], w_cells: usize, h_cells: usize, samples: &[f32]) {
+    let w_px = w_cells * 2;
+    let h_px = (h_cells * 4) as i32;
+    let n = samples.len();
+    let mut prev: Option<(i32, i32)> = None;
+
+    for col in 0..w_px {
+        let begin = col * n / w_px;
+        let end = ((col + 1) * n / w_px).clamp(begin + 1, n);
+        let (mut lo, mut hi) = (samples[begin], samples[begin]);
+        for &v in &samples[begin..end] {
+            lo = lo.min(v);
+            hi = hi.max(v);
+        }
+
+        let (top, bottom) = (sample_row(hi, h_px), sample_row(lo, h_px));
+        let (mut from, mut to) = (top, bottom);
+        if let Some((prev_top, prev_bottom)) = prev {
+            from = from.min(prev_bottom);
+            to = to.max(prev_top);
+        }
+        for y in from..=to {
+            set_pixel(grid, w_cells, h_cells, col as i32, y);
+        }
+        // 接合用本列的原始跨度，否则延伸量会逐列累积。
+        prev = Some((top, bottom));
+    }
+}
+
+/// 样本值 → 像素行：+1 在顶、-1 在底。EQ 提升可能让样本越过 ±1，故钳位。
+fn sample_row(v: f32, h_px: i32) -> i32 {
+    let span = (h_px - 1) as f32;
+    ((1.0 - v) * 0.5 * span).round().clamp(0.0, span) as i32
+}
+
+/// 逐单元格直写帧缓冲：颜色按格变化（左声道 / 右声道 / 中线三种），
+/// 整行一个 Span 表达不了，直写也省掉每帧的字符串分配。
+fn paint(f: &mut Frame, area: Rect, app: &AppState, w_cells: usize, h_cells: usize) {
+    let scope = &app.scope;
+    let h_px = (h_cells * 4) as i32;
+
+    // 中线 graticule：用盲文点位精确落在零电平那一子行上，而非单元格的几何中心。
+    let zero_row = sample_row(0.0, h_px) as usize;
+    let (graticule_row, graticule_sub) = (zero_row / 4, zero_row % 4);
+    let graticule =
+        braille_from_bits(braille_bit(0, graticule_sub) | braille_bit(1, graticule_sub));
+    let graticule_fg = app.theme.color_subtext();
+
+    let buf = f.buffer_mut();
+    let clip = area.intersection(buf.area);
+
+    for row in 0..clip.height as usize {
         let t = if h_cells <= 1 {
             1.0
         } else {
             row as f32 / (h_cells - 1) as f32
         };
-        let fg = vertical_gradient_color(app, t);
-        let mut s = String::with_capacity(w_cells);
-        let base = row * w_cells;
-        for col in 0..w_cells {
-            let bits = cell_bits[base + col];
-            s.push(braille_from_bits(bits));
-        }
-        lines.push(Line::from(Span::styled(s, Style::default().fg(fg))));
-    }
+        let trace_fg = vertical_gradient_color(app, t);
+        let right_fg = mix(trace_fg, app.theme.color_base(), RIGHT_CHANNEL_DIM);
 
-    f.render_widget(Paragraph::new(lines), area);
-}
+        for col in 0..clip.width as usize {
+            let index = row * w_cells + col;
+            let left = scope.left[index];
+            let right = if scope.stereo { scope.right[index] } else { 0 };
 
-pub fn advance_phases(phases: &mut [f32; BINS], dt_sec: f32) {
-    if dt_sec <= 0.0 {
-        return;
-    }
-    let dt_sec = dt_sec.clamp(1.0 / 240.0, 1.0 / 5.0);
-    for k in 0..BINS {
-        let f = freq_for_bin(k);
-        phases[k] = wrap_tau(phases[k] + std::f32::consts::TAU * f * dt_sec);
-    }
-}
+            // 两声道重叠的格子归左声道：亮色压暗色，与叠加显示的惯例一致。
+            let (glyph, fg) = match (left, right) {
+                (0, 0) if row == graticule_row => (graticule, graticule_fg),
+                (0, 0) => continue,
+                (0, r) => (braille_from_bits(r), right_fg),
+                (l, r) => (braille_from_bits(l | r), trace_fg),
+            };
 
-fn synthesize_waveforms(app: &AppState, w_px: usize, mid_y: i32) -> (Vec<i32>, Vec<i32>) {
-    // Use a subset of bins for performance while keeping the look.
-    let bin_step = 2usize;
-
-    let mut out_left: Vec<i32> = Vec::with_capacity(w_px);
-    let mut out_right: Vec<i32> = Vec::with_capacity(w_px);
-
-    let denom_left = amplitude_denominator(&app.spectrum.stereo_left, bin_step);
-    let denom_right = amplitude_denominator(&app.spectrum.stereo_right, bin_step);
-
-    for x in 0..w_px {
-        let t = (x as f32 / (w_px.saturating_sub(1).max(1) as f32)) * DISPLAY_WINDOW_SEC;
-
-        let y_l = synth_channel(
-            &app.spectrum.stereo_left,
-            &app.spectrum.osc_phase_left,
-            denom_left,
-            t,
-            bin_step,
-        );
-        let y_r = synth_channel(
-            &app.spectrum.stereo_right,
-            &app.spectrum.osc_phase_right,
-            denom_right,
-            t,
-            bin_step,
-        );
-
-        out_left.push(map_to_pixel_row(y_l, mid_y));
-        out_right.push(map_to_pixel_row(y_r, mid_y));
-    }
-
-    (out_left, out_right)
-}
-
-fn amplitude_denominator(vals: &[f32; BINS], bin_step: usize) -> f32 {
-    let mut sum = 0.0f32;
-    for k in (0..BINS).step_by(bin_step) {
-        sum += vals[k].clamp(0.0, 1.0).powf(GAMMA);
-    }
-    sum.max(1e-3)
-}
-
-fn synth_channel(
-    vals: &[f32; BINS],
-    phases: &[f32; BINS],
-    denom: f32,
-    t: f32,
-    bin_step: usize,
-) -> f32 {
-    let mut acc = 0.0f32;
-    for k in (0..BINS).step_by(bin_step) {
-        let a = vals[k].clamp(0.0, 1.0).powf(GAMMA);
-        if a <= 0.0 {
-            continue;
-        }
-        let f = freq_for_bin(k);
-        let theta = std::f32::consts::TAU * f * t + phases[k];
-        acc += a * theta.sin();
-    }
-
-    // Normalize to roughly [-1, 1].
-    (acc / denom).clamp(-1.0, 1.0)
-}
-
-fn map_to_pixel_row(y: f32, mid_y: i32) -> i32 {
-    let span = (mid_y as f32).max(1.0);
-    let yy = (mid_y as f32) - (y * GAIN * span);
-    yy.round() as i32
-}
-
-fn rasterize_braille(w_cells: usize, h_cells: usize, y_left: &[i32], y_right: &[i32]) -> Vec<u8> {
-    let w_px = (w_cells * 2) as i32;
-    let h_px = (h_cells * 4) as i32;
-
-    let mut bits: Vec<u8> = vec![0u8; w_cells * h_cells];
-
-    // Draw both channels as continuous lines (overlayed).
-    draw_polyline(&mut bits, w_cells, h_cells, y_left, w_px, h_px);
-    draw_polyline(&mut bits, w_cells, h_cells, y_right, w_px, h_px);
-
-    bits
-}
-
-fn draw_polyline(
-    bits: &mut [u8],
-    w_cells: usize,
-    h_cells: usize,
-    ys: &[i32],
-    w_px: i32,
-    h_px: i32,
-) {
-    if ys.is_empty() {
-        return;
-    }
-
-    let mut prev_x = 0i32;
-    let mut prev_y = ys[0].clamp(0, h_px - 1);
-
-    for (xi, &raw_y) in ys.iter().enumerate().skip(1) {
-        let x = (xi as i32).clamp(0, w_px - 1);
-        let y = raw_y.clamp(0, h_px - 1);
-        draw_line_px(bits, w_cells, h_cells, prev_x, prev_y, x, y);
-        prev_x = x;
-        prev_y = y;
-    }
-}
-
-fn draw_line_px(
-    bits: &mut [u8],
-    w_cells: usize,
-    h_cells: usize,
-    x0: i32,
-    y0: i32,
-    x1: i32,
-    y1: i32,
-) {
-    // Bresenham line in pixel space.
-    let mut x0 = x0;
-    let mut y0 = y0;
-    let dx = (x1 - x0).abs();
-    let sx = if x0 < x1 { 1 } else { -1 };
-    let dy = -(y1 - y0).abs();
-    let sy = if y0 < y1 { 1 } else { -1 };
-    let mut err = dx + dy;
-
-    loop {
-        set_pixel(bits, w_cells, h_cells, x0, y0);
-        if x0 == x1 && y0 == y1 {
-            break;
-        }
-        let e2 = 2 * err;
-        if e2 >= dy {
-            err += dy;
-            x0 += sx;
-        }
-        if e2 <= dx {
-            err += dx;
-            y0 += sy;
+            if let Some(cell) = buf.cell_mut((clip.x + col as u16, clip.y + row as u16)) {
+                cell.set_char(glyph);
+                cell.set_fg(fg);
+            }
         }
     }
 }
@@ -224,9 +252,7 @@ fn set_pixel(bits: &mut [u8], w_cells: usize, h_cells: usize, x: i32, y: i32) {
 
     let dx = (x % 2) as usize;
     let dy = (y % 4) as usize;
-    let bit = braille_bit(dx, dy);
-    let idx = cell_y * w_cells + cell_x;
-    bits[idx] |= bit;
+    bits[cell_y * w_cells + cell_x] |= braille_bit(dx, dy);
 }
 
 fn braille_bit(dx: usize, dy: usize) -> u8 {
@@ -251,34 +277,14 @@ fn braille_from_bits(bits: u8) -> char {
     char::from_u32(0x2800 + bits as u32).unwrap_or(' ')
 }
 
-fn freq_for_bin(k: usize) -> f32 {
-    if BINS <= 1 {
-        return F_MIN_HZ;
-    }
-    let t = (k as f32 / (BINS - 1) as f32).clamp(0.0, 1.0);
-    let ratio = F_MAX_HZ / F_MIN_HZ;
-    F_MIN_HZ * ratio.powf(t)
-}
-
-fn wrap_tau(mut x: f32) -> f32 {
-    let tau = std::f32::consts::TAU;
-    if !x.is_finite() {
-        return 0.0;
-    }
-    // Keep in [0, TAU).
-    x %= tau;
-    if x < 0.0 {
-        x += tau;
-    }
-    x
-}
-
 fn vertical_gradient_color(app: &AppState, t: f32) -> Color {
     let top = app.theme.color_accent2();
     let bottom = app.theme.color_accent3();
     mix(top, bottom, t)
 }
 
+/// 非 truecolor 终端（`Ansi256` / `NoColor`）上主题色不是 `Color::Rgb`，
+/// 此处退化为返回 `a`：渐变塌成单色、左右声道同色。与既有频谱渲染的降级一致。
 fn mix(a: Color, b: Color, t: f32) -> Color {
     let t = t.clamp(0.0, 1.0);
     match (a, b) {

--- a/src/tmplayer/ui/tui.rs
+++ b/src/tmplayer/ui/tui.rs
@@ -650,9 +650,7 @@ fn render_bar_settings_modal(f: &mut ratatui::Frame, size: Rect, app: &mut AppSt
     ];
 
     for (idx, text) in items.iter().enumerate() {
-        let style = if idx == 0 && !crate::tmplayer::audio::cava::is_available() {
-            Style::default().fg(app.theme.color_subtext())
-        } else if idx == app.bar_settings_selected {
+        let style = if idx == app.bar_settings_selected {
             Style::default()
                 .fg(app.theme.color_accent2())
                 .add_modifier(Modifier::BOLD)

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -211,9 +211,7 @@ fn draw_playback_settings(frame: &mut Frame, app: &App, inner: Rect) {
         .iter()
         .enumerate()
         .map(|(idx, text)| {
-            let style = if idx == 0 && !crate::tmplayer::audio::cava::is_available() {
-                Style::default().fg(app.theme.color_subtext())
-            } else if idx == app.settings_playback_selected {
+            let style = if idx == app.settings_playback_selected {
                 Style::default()
                     .fg(app.theme.color_accent2())
                     .add_modifier(Modifier::BOLD)


### PR DESCRIPTION
## 概要

示波器从 cava 频谱合成改为真 PCM 时域波形；搜索切换到新版 `cloudsearch` 接口修复封面缺失。

## 示波器改用真 PCM 波形

原实现是 cava 64 频段的加性正弦合成：cava 被配成 Mono 导致左右声道逐像素完全重合，相位每帧伪随机跳变（注释声称"跨帧稳定"与实际不符），30ms 窗口下高频段严重欠采样，且振幅按幅度和自归一化因而丢失响度动态。

新实现在播放链路上加 PCM 抽头，照搬硬件示波器的三个要素：

- **上升沿触发**（滞回 5% 峰值，下限 1e-4）：每帧在 25ms 搜索区间内取最后一个带滞回的零交叉作为窗口起点，周期信号因此在屏上静止。没有它，窗口只能随时间平移，画面是一片沸腾的噪点。
- **峰值（min/max）抽取**：每子列画该段样本的极值包络带。包络对时域欠采样免疫，高频段因此是稳定实心带而非混叠锯齿 —— 即示波器的 peak-detect 采集模式。
- **绝对幅度映射**：不归一化、不做 AGC，响度动态如实呈现。

抽头取 EQ 之后、音量之前：波形反映均衡效果但不随音量缩放。

### 线程模型

写侧跑在 cpal 实时回调线程，因此 `PcmRing::push` 用 `try_lock`，抢不到整批丢弃（12ms 不可感知）；读侧渲染线程用阻塞 `lock`（丢快照会闪空）。`PcmTap` 攒满 512 帧才落环，把加锁频率从每秒 88200 次降到约 86 次。`reset()` 只是 generation 原子自增，故可从任意线程（含音频线程）调用。

### 起振/回落包络

照搬 cava `cavacore.c` 的两级平滑：起振用 integral（一阶滞后，≈100ms 到九成），回落用 falloff（自由落体，位移正比于时长平方）。常量全部从 cava 源码反解并注明出处。

不用指数衰减的原因：指数首帧就掉 35%、三帧只剩 27%，在几百毫秒尺度上看起来是瞬间归零，看不出动画；自由落体前段几乎不动、跌落集中在后半段。`fall_is_gravity_shaped_not_exponential` 断言第 3 帧仍留九成以上，守着这条。

包络是全局标量而非按列分开，所以所有盲文列同时落平。静止时那条居中直线就是 `gain = 0` 的波形本身，没有独立的中线元素。

### cava 依赖解耦

新增 `VisualizeMode::needs_cava()` / `is_available()`，替代散落的可用性判断。示波器不再需要 cava，因此：全屏页在示波器模式下不起 cava 子进程；`cycle()` 改为按方向逐个试探跳过不可用模式；无 cava 时默认与强制回退从 `Off` 改为 `Oscilloscope`；两处设置 UI 删掉"无 cava 置灰"分支。

宿主主页 `sync_cava` 未改 —— 播放条那 10 字符 mini 频谱仍需 20 bars，且是唯一消费者。

## 搜索改用 cloudsearch

老 `/api/search/get` 的 songs 项不含专辑封面字段，`parse_song_items` 的两条 JSON 路径同时落空，`SearchItem.cover_url` 恒为 `None`。而下游每一处封面兜底都以 `cover_url` 存在为前提，None 会让它们逐个放弃 —— 表现为搜索进入的歌曲在全屏页没有封面。

`cloudsearch`（`/api/cloudsearch/pc`）返回体与 `song/detail` 同族用 `al`/`ar` 字段，既有的 `/al/picUrl` 路径直接命中，无需任何补址代码。

## 测试

`cargo test`：27 passed。其中 `rise_matches_cava_integral` / `fall_matches_cava_falloff` 在测试里用 Rust 重跑一遍 cava 的 C 循环（含 prev/peak/fall/mem 全部状态），逐帧比对到 1e-3。

`cargo build --release --locked`：0 error。新增文件零 clippy 警告。

## 实测验收

盲文解码量化验证（200×50 终端、真实 FLAC、132 列面板 = 264 子列）：

| 判据 | 实测 |
|---|---|
| 第 0 子列偏离中线 | 2.5–3.0 子行（触发锁相） |
| 点亮子列数 | 264 / 264（包络连续无断点） |
| 帧间跨度变化 | 50 → 67 子行（绝对幅度） |
| 帧间变化子列 | 263 / 264（画面实时） |
| 暂停回落 | max_span 13 → 4 → 1 → 0，约 0.27s 落平 |
| 静止帧字形 | 整行不间断 `⠤` |

示波器模式下 `pgrep -P <pid>` 连续采样确认全屏页无 cava 子进程。

## 已知遗留

`VisualizeMode` 仍在 `src/data/config.rs` 与 `src/tmplayer/data/config.rs` 重复定义两份，`needs_cava`/`is_available` 各写一遍。属改造前既有结构，本次未扩大也未收敛。
