### PR TITLE
修 release 工作流：Release 缺 checkout、AUR 权限、sha256 替换失效

### DIFF
--- a/.github/scripts/aur_sync.sh
+++ b/.github/scripts/aur_sync.sh
@@ -27,19 +27,28 @@ git clone -q ssh://aur@aur.archlinux.org/cnmplayer-bin.git
 cd cnmplayer-bin
 sed -i "s/^pkgver=.*/pkgver=${VER}/" PKGBUILD
 sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
-# PKGBUILD 中 URL 为参数化写法（${pkgver}/${_asset_arch}），
-# 须 source 求值得到展开后的真实 URL（与 makepkg 同机制），再按架构行原位重算 sha256。
-# 兼容未来加入 source_aarch64：届时无需改动本脚本。
+# PKGBUILD 中 URL 为参数化写法（${pkgver} 等），须 source 求值得到展开后的真实
+# URL（与 makepkg 同机制），再按架构重算 sha256。
+#
+# 注意 sed 必须锚定 sha256sums_${arch}= 那一行：早先版本取的是 source_${arch}= 的
+# 行号，而校验和在其下一行，替换因此静默失效（no-op），推出的包会带上一版的旧
+# 校验和、安装时校验失败。
 for arch in x86_64 aarch64; do
   grep -q "^source_${arch}=" PKGBUILD || continue
-  line_no=$(grep -n "^source_${arch}=" PKGBUILD | cut -d: -f1)
   url=$(CARCH="${arch}" bash -ec "source ./PKGBUILD; printf '%s\n' \"\${source_${arch}[@]}\"" | grep '\.tar\.xz')
   url="${url##*::}"
   [ -n "$url" ] || { echo "no tar.xz asset resolved for ${arch}"; exit 1; }
-  f=$(basename "${url}")
+  f="${arch}-$(basename "${url}")"
   curl -fsSL "${url}" -o "/tmp/${f}"
   newsum=$(sha256sum "/tmp/${f}" | cut -d' ' -f1)
-  sed -i "${line_no}s/[0-9a-f]\{64\}/${newsum}/" PKGBUILD
+
+  sum_line=$(grep -n "^sha256sums_${arch}=" PKGBUILD | cut -d: -f1)
+  [ -n "$sum_line" ] || { echo "no sha256sums_${arch}= line in PKGBUILD"; exit 1; }
+  sed -i "${sum_line}s/[0-9a-f]\{64\}/${newsum}/" PKGBUILD
+
+  # 校验替换确实生效，避免再次静默失败
+  grep -q "^sha256sums_${arch}=.*${newsum}" PKGBUILD \
+    || { echo "failed to update sha256sums_${arch}"; exit 1; }
 done
 makepkg --printsrcinfo > .SRCINFO
 if git commit -aqm "functional update"; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,8 @@ jobs:
           fi
 
   build:
-    name: Build ${{ matrix.target }}
+    # 用产物架构名（amd64/aarch64）而非 Rust 三元组：与 tarball 名一致，也更短
+    name: Build ${{ matrix.arch }}
     needs: guard
     strategy:
       fail-fast: false
@@ -124,10 +125,18 @@ jobs:
     permissions:
       contents: write
     steps:
+      # gh release create --verify-tag 需要 git 仓库上下文来校验 tag，
+      # 缺了 checkout 会以 "fatal: not a git repository" 失败。
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.guard.outputs.tag }}
+
+      # 下到子目录：避免 ./*.tar.xz 把仓库自身文件也匹配进去
       - uses: actions/download-artifact@v4
         with:
           pattern: rel-*
           merge-multiple: true
+          path: dist
 
       # create 已存在时回退为 upload，保证 re-run 幂等
       - name: Create release with tarballs
@@ -135,8 +144,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.guard.outputs.tag }}
         run: |
-          gh release create "$TAG" --verify-tag --generate-notes ./*.tar.xz \
-            || gh release upload "$TAG" --clobber ./*.tar.xz
+          gh release create "$TAG" --verify-tag --generate-notes dist/*.tar.xz \
+            || gh release upload "$TAG" --clobber dist/*.tar.xz
 
   aur:
     name: Sync AUR packages
@@ -187,4 +196,10 @@ jobs:
             TAG="$GITHUB_REF_NAME"
             DRY_RUN=false
           fi
-          sudo -u builder -H bash "$GITHUB_WORKSPACE/.github/scripts/aur_sync.sh" "$TAG" "$DRY_RUN"
+          # 脚本在 cwd 里 git clone 两个 AUR 仓库，而 $GITHUB_WORKSPACE 属 root，
+          # builder 无写权限（曾以 "could not create work tree dir: Permission denied"
+          # 失败）。因此在 builder 自己的 HOME 下另开一个工作目录。
+          workdir=/home/builder/aur
+          install -d -m755 -o builder -g builder "$workdir"
+          sudo -u builder -H bash -c \
+            "cd '$workdir' && bash '$GITHUB_WORKSPACE/.github/scripts/aur_sync.sh' '$TAG' '$DRY_RUN'"


### PR DESCRIPTION
## 背景

v0.5.2 打 tag 后首次真实发版（run 33263914273）：双架构构建**成功**，但 `GitHub Release` 与 `Sync AUR packages` 两个 job 全部失败，Release 未创建。版本号仍为 0.5.2，本 PR 只修工作流，合并后重跑同一个 tag 即可。

## 三处缺陷

### 1. publish 缺 `actions/checkout`

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

`gh release create --verify-tag` 需要 git 仓库上下文来校验 tag，而该 job 只做了 `download-artifact`。补上 checkout。

同时把资产下载到 `dist/` 子目录——原先下到工作目录根，加了 checkout 后 `./*.tar.xz` 有误匹配仓库文件的风险。

### 2. aur job 的工作目录 builder 无写权限

```
fatal: could not create work tree dir 'cnmplayer': Permission denied
```

`sudo -u builder` 继承 `$GITHUB_WORKSPACE` 作为 cwd，该目录属 root，而脚本要在 cwd 里 clone 两个 AUR 仓库。改为在 builder 自己的 HOME 下另开 `/home/builder/aur` 并 `cd` 进去。

### 3. `aur_sync.sh` 的 sha256 替换是静默 no-op

这条最危险，不会报错但会推出坏包。

```bash
line_no=$(grep -n "^source_${arch}=" PKGBUILD | cut -d: -f1)   # ← source 行
sed -i "${line_no}s/[0-9a-f]\{64\}/${newsum}/" PKGBUILD          # ← 在 source 行找 sha256
```

`sed` 锚定的是 `source_${arch}=` 的行号，而校验和在**下一行**的 `sha256sums_${arch}=`。source 行没有 64 位十六进制串，替换因此完全不生效。本地实测确认：

```
source line: 25
>>> 该行无 64 位十六进制串 → sed 替换是 no-op
```

后果：`pkgver` 升到新版、`source` URL 指向新版资产，但 `sha256sums` 仍是上一版的值 —— 用户 `makepkg` 必然校验失败。`cnmplayer-bin` 此前只有一个提交、停留在 0.5.1，所以这个缺陷还没在真实发版中暴露过，v0.5.2 会是首次。

改为锚定 `sha256sums_${arch}=` 行，并在替换后 `grep` 校验确实生效，避免再次静默失败。下载的临时文件名也加了架构前缀，防止双架构同名冲突。

### 4. 构建 job 显示名

`Build x86_64-unknown-linux-gnu` → `Build amd64`。用产物架构名而非 Rust 三元组，与 tarball 命名一致，也更短。

## 配套：cnmplayer-bin 多架构

AUR 包在独立仓库（`fin/AUR/cnmplayer-bin`，不在本仓库内），已同步补齐：

- `arch` 数组加入 `'aarch64'`
- 新增 `source_aarch64` / `sha256sums_aarch64`
- 两个架构的 tarball 用不同本地文件名（`-x86_64` / `-aarch64` 后缀），避免 makepkg 缓存冲突
- URL 里直接写死资产名（`amd64`/`aarch64`）而不引用 `CARCH`——资产命名与 `CARCH` 不同名，且 makepkg 只取当前架构对应的 `source_*` 数组

`aur_sync.sh` 的 `for arch in x86_64 aarch64` 循环本就带 `grep -q "^source_${arch}=" || continue`，所以脚本侧无需为此改动。

## 验证

- `release.yml` YAML 解析通过，4 个 job 结构正确，publish 步骤为 checkout → download-artifact → create
- `aur_sync.sh` `bash -n` 语法通过
- sed 定位缺陷已用本地 PKGBUILD 复现并确认修复后可命中

## 合并后

重跑 v0.5.2 的 release 工作流（tag 已存在，无需重打）。
